### PR TITLE
feat(auth): short-lived JWT access tokens, refresh rotation, and revocation fixes

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -14,9 +14,8 @@ import * as bcrypt from 'bcrypt';
 import { RedisService } from '../common/services/redis.service';
 import { v4 as uuidv4 } from 'uuid';
 import { StructuredLoggerService } from '../common/logging/logger.service';
-import { AuthUser, JwtPayload, AuthTokens } from './auth.types';
-import { PrismaUser } from '../types/prisma.types';
-import { isObject, isString } from '../types/guards';
+import { JwtPayload } from './auth.types';
+import { JWT_TOKEN_USE, tokenRevocationRedisKeys } from './constants';
 
 @Injectable()
 export class AuthService {
@@ -139,9 +138,14 @@ export class AuthService {
 
   async refreshToken(refreshToken: string) {
     try {
-      const payload = await this.jwtService.verifyAsync(refreshToken, {
+      const payload = (await this.jwtService.verifyAsync(refreshToken, {
         secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
-      });
+      })) as JwtPayload;
+
+      if (payload.tokenUse !== JWT_TOKEN_USE.REFRESH || !payload.rid) {
+        this.logger.warn('Refresh token validation failed: wrong token type', { userId: payload.sub });
+        throw new TokenExpiredException('Invalid refresh token');
+      }
 
       const user = await this.userService.findById(payload.sub);
       if (!user) {
@@ -151,18 +155,19 @@ export class AuthService {
         throw new UserNotFoundException(payload.sub);
       }
 
-      const storedToken = await this.redisService.get(`refresh_token:${payload.sub}`);
-      if (storedToken !== refreshToken) {
-        this.logger.warn('Refresh token validation failed: Invalid token', {
-          userId: payload.sub,
-        });
+      const boundUserId = await this.redisService.get(tokenRevocationRedisKeys.refreshSession(payload.rid));
+      const currentRid = await this.redisService.get(tokenRevocationRedisKeys.userRefreshSession(payload.sub));
+
+      if (boundUserId !== payload.sub || currentRid !== payload.rid) {
+        this.logger.warn('Refresh token validation failed: revoked or rotated', { userId: payload.sub });
         throw new TokenExpiredException('Invalid refresh token');
       }
 
       this.logger.logAuth('Token refreshed successfully', { userId: user.id });
       return this.generateTokens(user);
     } catch (error) {
-      this.logger.error('Token refresh failed', error.stack);
+      const stack = error instanceof Error ? error.stack : undefined;
+      this.logger.error('Token refresh failed', stack);
       throw new TokenExpiredException('Invalid refresh token');
     }
   }
@@ -177,7 +182,7 @@ export class AuthService {
         if (jti && expiry) {
           const ttl = expiry - Math.floor(Date.now() / 1000);
           if (ttl > 0) {
-            await this.redisService.setex(`blacklisted_token:${jti}`, ttl, userId);
+            await this.redisService.setex(tokenRevocationRedisKeys.accessRevoked(jti), ttl, userId);
             this.logger.logAuth('Access token blacklisted', { userId, jti });
           }
         }
@@ -187,7 +192,7 @@ export class AuthService {
     // === REFRESH TOKEN REVOCATION ===
     // Prevents token refresh even if JWT signature is still valid
 
-    await this.redisService.del(`refresh_token:${userId}`);
+    await this.clearRefreshSessionForUser(userId);
     this.logger.logAuth('User logged out successfully', { userId });
     return { message: 'Logged out successfully' };
   }
@@ -231,6 +236,7 @@ export class AuthService {
 
     await this.userService.updatePassword(userId, newPassword);
     await this.redisService.del(`password_reset:${resetToken}`);
+    await this.invalidateAllSessions(userId);
 
     this.logger.log('Password reset successfully', { userId });
     return { message: 'Password reset successfully' };
@@ -252,8 +258,11 @@ export class AuthService {
     return { message: 'Email verified successfully' };
   }
 
+  /**
+   * Access-token revocation list (Redis). Entries use TTL so the key expires with the JWT.
+   */
   async isTokenBlacklisted(jti: string): Promise<boolean> {
-    const blacklisted = await this.redisService.get(`blacklisted_token:${jti}`);
+    const blacklisted = await this.redisService.get(tokenRevocationRedisKeys.accessRevoked(jti));
     return blacklisted !== null;
   }
 
@@ -290,6 +299,7 @@ export class AuthService {
     for (const key of sessionKeys) {
       await this.redisService.del(key);
     }
+    await this.clearRefreshSessionForUser(userId);
     this.logger.logAuth('All sessions invalidated', { userId });
   }
 
@@ -310,42 +320,80 @@ export class AuthService {
     this.logger.logAuth('Session invalidated', { userId, sessionId });
   }
 
-  private generateTokens(user: any) {
-    // === UNIQUE JWT ID (JTI) ===
-    // Enables per-token blacklisting even if JWT signature is still valid
+  private async clearRefreshSessionForUser(userId: string): Promise<void> {
+    const rid = await this.redisService.get(tokenRevocationRedisKeys.userRefreshSession(userId));
+    if (rid) {
+      await this.redisService.del(tokenRevocationRedisKeys.refreshSession(rid));
+    }
+    await this.redisService.del(tokenRevocationRedisKeys.userRefreshSession(userId));
+  }
+
+  private refreshSessionTtlSeconds(refreshToken: string): number {
+    const decoded = this.jwtService.decode(refreshToken) as { exp?: number } | null;
+    if (!decoded?.exp) {
+      return 0;
+    }
+    return Math.max(0, decoded.exp - Math.floor(Date.now() / 1000));
+  }
+
+  private async generateTokens(user: any) {
+    await this.clearRefreshSessionForUser(user.id);
+
     const jti = uuidv4();
-    const payload = {
-      sub: user.id, // Subject (user ID)
+    const refreshSessionId = uuidv4();
+
+    const accessPayload: JwtPayload = {
+      sub: user.id,
       email: user.email,
-      jti, // JWT ID for blacklisting
+      jti,
+      tokenUse: JWT_TOKEN_USE.ACCESS,
     };
 
-    const accessToken = this.jwtService.sign(payload, {
+    const refreshPayload: JwtPayload = {
+      sub: user.id,
+      email: user.email,
+      rid: refreshSessionId,
+      tokenUse: JWT_TOKEN_USE.REFRESH,
+    };
+
+    const accessToken = this.jwtService.sign(accessPayload, {
       secret: this.configService.get<string>('JWT_SECRET'),
       expiresIn: this.configService.get<string>('JWT_EXPIRES_IN', '15m') as any,
     });
 
-    const refreshToken = this.jwtService.sign(payload, {
+    const refreshToken = this.jwtService.sign(refreshPayload, {
       secret: this.configService.get<string>('JWT_REFRESH_SECRET'),
       expiresIn: this.configService.get<string>('JWT_REFRESH_EXPIRES_IN', '7d') as any,
     });
 
-    this.redisService.set(`refresh_token:${user.id}`, refreshToken);
+    let refreshTtl = this.refreshSessionTtlSeconds(refreshToken);
+    if (refreshTtl <= 0) {
+      refreshTtl = 7 * 24 * 60 * 60;
+    }
+    await this.redisService.setex(
+      tokenRevocationRedisKeys.refreshSession(refreshSessionId),
+      refreshTtl,
+      user.id,
+    );
+    await this.redisService.setex(
+      tokenRevocationRedisKeys.userRefreshSession(user.id),
+      refreshTtl,
+      refreshSessionId,
+    );
 
-    // Store active session
     const sessionExpiry = this.configService.get<number>('SESSION_TIMEOUT', 3600);
-    this.redisService.setex(
+    await this.redisService.setex(
       `active_session:${user.id}:${jti}`,
       sessionExpiry,
       JSON.stringify({
         userId: user.id,
         createdAt: new Date().toISOString(),
-        userAgent: 'unknown', // Would be captured from request in real implementation
+        userAgent: 'unknown',
         ip: 'unknown',
       }),
     );
 
-    this.logger.debug('Generated new tokens for user', { userId: user.id, jti });
+    this.logger.debug('Generated new tokens for user', { userId: user.id, jti, refreshSessionId });
 
     return {
       access_token: accessToken,

--- a/src/auth/auth.types.ts
+++ b/src/auth/auth.types.ts
@@ -17,6 +17,10 @@ export interface JwtPayload {
   sub: string;
   email: string;
   jti?: string;
+  /** Refresh rotation id; present only on refresh JWTs. */
+  rid?: string;
+  /** Distinguishes access vs refresh tokens when both are JWTs. */
+  tokenUse?: 'access' | 'refresh';
   iat?: number;
   exp?: number;
 }

--- a/src/auth/constants.ts
+++ b/src/auth/constants.ts
@@ -1,3 +1,18 @@
 export const jwtConstants = {
   secret: process.env.JWT_SECRET || 'default_secret_for_development',
 };
+
+/** Access vs refresh JWT claim; prevents using an access JWT on the refresh endpoint. */
+export const JWT_TOKEN_USE = {
+  ACCESS: 'access',
+  REFRESH: 'refresh',
+} as const;
+
+/**
+ * Redis keys for token revocation: access-token denylist (by jti) and refresh rotation (by session id).
+ */
+export const tokenRevocationRedisKeys = {
+  accessRevoked: (jti: string) => `blacklisted_token:${jti}`,
+  refreshSession: (refreshSessionId: string) => `refresh_session:${refreshSessionId}`,
+  userRefreshSession: (userId: string) => `user_refresh_rid:${userId}`,
+} as const;

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -3,6 +3,8 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { UserService } from '../../users/user.service';
+import { JWT_TOKEN_USE } from '../constants';
+import { JwtPayload } from '../auth.types';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -17,13 +19,23 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: any) {
+  async validate(payload: JwtPayload) {
+    if (payload.tokenUse === JWT_TOKEN_USE.REFRESH) {
+      throw new UnauthorizedException();
+    }
+
     const user = await this.userService.findById(payload.sub);
 
     if (!user) {
       throw new UnauthorizedException();
     }
 
-    return user;
+    const { password: _, ...safe } = user as Record<string, unknown> & { password?: string };
+
+    return {
+      ...safe,
+      jti: payload.jti,
+      tokenUse: payload.tokenUse ?? JWT_TOKEN_USE.ACCESS,
+    };
   }
 }

--- a/src/config/validation/config.validation.ts
+++ b/src/config/validation/config.validation.ts
@@ -23,7 +23,7 @@ export const configValidationSchema = Joi.object({
 
   // JWT
   JWT_SECRET: Joi.string().min(32).required(),
-  JWT_EXPIRES_IN: Joi.string().default('24h'),
+  JWT_EXPIRES_IN: Joi.string().default('15m'),
   JWT_REFRESH_SECRET: Joi.string().min(32).required(),
   JWT_REFRESH_EXPIRES_IN: Joi.string().default('7d'),
 

--- a/test/auth/auth.service.spec.ts
+++ b/test/auth/auth.service.spec.ts
@@ -4,12 +4,13 @@ import { UserService } from '../../src/users/user.service';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { RedisService } from '../../src/common/services/redis.service';
-import { CreateUserDto } from '../../src/users/dto/create-user.dto';
 import { StructuredLoggerService } from '../../src/common/logging/logger.service';
+import { TokenExpiredException } from '../../src/common/errors/custom.exceptions';
 
 describe('AuthService', () => {
   let authService: AuthService;
   let userService: UserService;
+  let jwtService: JwtService;
   let redisMock: any;
   let configMock: any;
 
@@ -26,6 +27,11 @@ describe('AuthService', () => {
       get: jest.fn().mockImplementation((key: string) => {
         if (key === 'MAX_LOGIN_ATTEMPTS') return 5;
         if (key === 'LOGIN_ATTEMPT_WINDOW') return 600;
+        if (key === 'JWT_SECRET') return 'test-jwt-secret-that-is-at-least-32-characters';
+        if (key === 'JWT_REFRESH_SECRET') return 'test-jwt-refresh-secret-that-is-long-enough';
+        if (key === 'JWT_EXPIRES_IN') return '15m';
+        if (key === 'JWT_REFRESH_EXPIRES_IN') return '7d';
+        if (key === 'SESSION_TIMEOUT') return 3600;
         return null;
       }),
     };
@@ -46,8 +52,11 @@ describe('AuthService', () => {
         {
           provide: JwtService,
           useValue: {
-            sign: jest.fn(),
+            sign: jest.fn().mockReturnValue('signed-jwt'),
             verifyAsync: jest.fn(),
+            decode: jest.fn().mockReturnValue({
+              exp: Math.floor(Date.now() / 1000) + 3600,
+            }),
           },
         },
         {
@@ -64,6 +73,48 @@ describe('AuthService', () => {
 
     authService = moduleRef.get<AuthService>(AuthService);
     userService = moduleRef.get<UserService>(UserService);
+    jwtService = moduleRef.get<JwtService>(JwtService);
+  });
+
+  describe('refreshToken', () => {
+    it('should reject token without refresh tokenUse', async () => {
+      jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+        sub: 'u1',
+        email: 'a@b.com',
+        tokenUse: 'access',
+        jti: 'jti-1',
+      } as any);
+
+      await expect(authService.refreshToken('tok')).rejects.toBeInstanceOf(TokenExpiredException);
+    });
+
+    it('should issue new tokens when refresh session matches', async () => {
+      const user = { id: 'u1', email: 'a@b.com', isVerified: true, walletAddress: null };
+      jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+        sub: 'u1',
+        email: 'a@b.com',
+        tokenUse: 'refresh',
+        rid: 'rid-1',
+      } as any);
+      jest.spyOn(userService, 'findById').mockResolvedValue(user as any);
+      redisMock.get.mockImplementation(async (key: string) => {
+        if (key.startsWith('refresh_session:')) {
+          return 'u1';
+        }
+        if (key.startsWith('user_refresh_rid:')) {
+          return 'rid-1';
+        }
+        return null;
+      });
+      redisMock.del.mockResolvedValue(1);
+      redisMock.setex.mockResolvedValue(undefined);
+
+      const result = await authService.refreshToken('valid-refresh');
+
+      expect(result.access_token).toBeDefined();
+      expect(result.refresh_token).toBeDefined();
+      expect(jwtService.sign).toHaveBeenCalled();
+    });
   });
 
   describe('login brute force protection', () => {


### PR DESCRIPTION
### Summary

Implements stricter JWT lifecycle management: **15-minute access tokens**, a **server-bound refresh flow with rotation**, and a working **access-token revocation list** (plus refresh invalidation where appropriate). Also fixes a bug where revoked access tokens could still be used because `jti` never reached `request.user`.

### Problem

- Validated config defaulted `JWT_EXPIRES_IN` to **24h**, overriding the intended short access-token lifetime.
- `JwtStrategy` returned only the database user, so **`jti` was dropped** and `JwtAuthGuard`’s denylist check almost never ran—**logout did not reliably invalidate the current access JWT** for API calls.
- Refresh tokens reused the access payload, were stored in Redis **without TTL**, and Redis writes were not consistently **awaited**, weakening session hygiene and rotation semantics.

### Solution

**Access tokens**

- Set Joi default **`JWT_EXPIRES_IN` to `15m`** so validated environments align with the product rule (still overridable via env).
- Access JWT payload includes `jti` and `tokenUse: 'access'` for explicit typing and blacklist support.

**Refresh tokens**

- Refresh JWTs use a dedicated shape: `tokenUse: 'refresh'` and a per-session **`rid`** (rotation id), signed with `JWT_REFRESH_SECRET`.
- Redis stores:
  - `refresh_session:{rid}` → user id  
  - `user_refresh_rid:{userId}` → current `rid`  
  Both use **TTL derived from the refresh JWT `exp`** so entries do not outlive the token.
- **Rotation**: each login or successful refresh clears the previous refresh binding and issues a new pair; presenting an old refresh JWT after rotation fails validation.
- **Bearer guard**: `JwtStrategy` **rejects** `tokenUse: 'refresh'` so access tokens cannot be used on refresh-only flows and refresh tokens are not accepted as API Bearer access tokens (when this strategy is used).

**Revocation**

- Access denylist remains **`blacklisted_token:{jti}`** with TTL = remaining token lifetime; keys are centralized in `tokenRevocationRedisKeys` for clarity.
- **Logout** continues to denylist the current access `jti` and clears the user’s refresh binding.
- **`invalidateAllSessions`** also clears refresh bindings.
- **Password reset** calls **`invalidateAllSessions`** so sessions and refresh tokens are revoked after a successful reset.

### Files changed (high level)

- `src/config/validation/config.validation.ts` — default access TTL.
- `src/auth/constants.ts` — `JWT_TOKEN_USE`, `tokenRevocationRedisKeys`.
- `src/auth/auth.types.ts` — `JwtPayload` extended with `rid` / `tokenUse`.
- `src/auth/auth.service.ts` — refresh verification, rotation, Redis TTL, awaited writes, session invalidation on password reset.
- `src/auth/strategies/jwt.strategy.ts` — merge `jti` / `tokenUse` into `request.user`; block refresh tokens on access.
- `test/auth/auth.service.spec.ts` — JWT config mocks and `refreshToken` cases.

### Client / API impact

- Clients **must persist the new `refresh_token`** returned from **`POST /auth/refresh-token`** after each refresh (rotation).
- Existing refresh tokens **without** `tokenUse` / `rid` will **stop working**; users need to **log in again** once.

### How to test

- `npm test -- test/auth/auth.service.spec.ts`
- Manual: login → call a protected route → logout → same access token should return **401**; refresh with stored refresh token should return a **new** pair; old refresh token should fail after a successful refresh.

### Checklist

- [x] Access token lifetime defaulted to 15m in validated config  
- [x] Refresh rotation + Redis-bound sessions with TTL  
- [x] Access revocation list effective (jti on `request.user`)  
- [x] Refresh revoked on logout / invalidate-all / password reset

Closes: #94 