### PR TITLE
feat: #416 Implement Fraud Detection

### DIFF
--- a/prisma/migrations/20260424010000_add_fraud_detection/migration.sql
+++ b/prisma/migrations/20260424010000_add_fraud_detection/migration.sql
@@ -1,0 +1,89 @@
+CREATE TYPE "FraudSeverity" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'CRITICAL');
+CREATE TYPE "FraudStatus" AS ENUM ('OPEN', 'INVESTIGATING', 'RESOLVED', 'DISMISSED');
+CREATE TYPE "FraudPattern" AS ENUM (
+  'EXCESSIVE_FAILED_LOGINS',
+  'SHARED_IP_MULTIPLE_ACCOUNTS',
+  'MULTIPLE_IPS_FOR_ACCOUNT',
+  'NEW_DEVICE_LOGIN',
+  'TOKEN_REUSE',
+  'RAPID_PROPERTY_LISTINGS',
+  'DUPLICATE_PROPERTY_ADDRESS',
+  'HIGH_VALUE_NEW_ACCOUNT_LISTING'
+);
+
+CREATE TABLE "fraud_alerts" (
+  "id" TEXT NOT NULL,
+  "user_id" TEXT,
+  "property_id" TEXT,
+  "transaction_id" TEXT,
+  "session_id" TEXT,
+  "pattern" "FraudPattern" NOT NULL,
+  "severity" "FraudSeverity" NOT NULL,
+  "status" "FraudStatus" NOT NULL DEFAULT 'OPEN',
+  "score" INTEGER NOT NULL DEFAULT 0,
+  "title" TEXT NOT NULL,
+  "description" TEXT NOT NULL,
+  "evidence" JSONB,
+  "auto_blocked" BOOLEAN NOT NULL DEFAULT false,
+  "first_detected_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "last_detected_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "occurrence_count" INTEGER NOT NULL DEFAULT 1,
+  "assigned_to_id" TEXT,
+  "resolved_by_id" TEXT,
+  "resolved_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "fraud_alerts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "fraud_investigation_notes" (
+  "id" TEXT NOT NULL,
+  "alert_id" TEXT NOT NULL,
+  "actor_id" TEXT,
+  "action" TEXT,
+  "note" TEXT NOT NULL,
+  "metadata" JSONB,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "fraud_investigation_notes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "fraud_alerts_status_severity_idx" ON "fraud_alerts"("status", "severity");
+CREATE INDEX "fraud_alerts_user_id_status_idx" ON "fraud_alerts"("user_id", "status");
+CREATE INDEX "fraud_alerts_property_id_status_idx" ON "fraud_alerts"("property_id", "status");
+CREATE INDEX "fraud_alerts_pattern_status_idx" ON "fraud_alerts"("pattern", "status");
+CREATE INDEX "fraud_alerts_last_detected_at_idx" ON "fraud_alerts"("last_detected_at");
+CREATE INDEX "fraud_investigation_notes_alert_id_created_at_idx"
+  ON "fraud_investigation_notes"("alert_id", "created_at");
+CREATE INDEX "fraud_investigation_notes_actor_id_idx" ON "fraud_investigation_notes"("actor_id");
+
+ALTER TABLE "fraud_alerts"
+  ADD CONSTRAINT "fraud_alerts_user_id_fkey"
+  FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_alerts"
+  ADD CONSTRAINT "fraud_alerts_property_id_fkey"
+  FOREIGN KEY ("property_id") REFERENCES "properties"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_alerts"
+  ADD CONSTRAINT "fraud_alerts_transaction_id_fkey"
+  FOREIGN KEY ("transaction_id") REFERENCES "transactions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_alerts"
+  ADD CONSTRAINT "fraud_alerts_session_id_fkey"
+  FOREIGN KEY ("session_id") REFERENCES "sessions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_alerts"
+  ADD CONSTRAINT "fraud_alerts_assigned_to_id_fkey"
+  FOREIGN KEY ("assigned_to_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_alerts"
+  ADD CONSTRAINT "fraud_alerts_resolved_by_id_fkey"
+  FOREIGN KEY ("resolved_by_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_investigation_notes"
+  ADD CONSTRAINT "fraud_investigation_notes_alert_id_fkey"
+  FOREIGN KEY ("alert_id") REFERENCES "fraud_alerts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "fraud_investigation_notes"
+  ADD CONSTRAINT "fraud_investigation_notes_actor_id_fkey"
+  FOREIGN KEY ("actor_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,31 @@ enum VerificationStatus {
   REJECTED
 }
 
+enum FraudSeverity {
+  LOW
+  MEDIUM
+  HIGH
+  CRITICAL
+}
+
+enum FraudStatus {
+  OPEN
+  INVESTIGATING
+  RESOLVED
+  DISMISSED
+}
+
+enum FraudPattern {
+  EXCESSIVE_FAILED_LOGINS
+  SHARED_IP_MULTIPLE_ACCOUNTS
+  MULTIPLE_IPS_FOR_ACCOUNT
+  NEW_DEVICE_LOGIN
+  TOKEN_REUSE
+  RAPID_PROPERTY_LISTINGS
+  DUPLICATE_PROPERTY_ADDRESS
+  HIGH_VALUE_NEW_ACCOUNT_LISTING
+}
+
 // User model
 model User {
   id                       String    @id @default(uuid())
@@ -100,21 +125,25 @@ model User {
   referredById             String?   @map("referred_by_id")
 
   // Relations
-  properties            Property[]
-  buyerTransactions     Transaction[]          @relation("BuyerTransactions")
-  sellerTransactions    Transaction[]          @relation("SellerTransactions")
-  documents             Document[]
-  apiKeys               ApiKey[]
-  passwordHistory       PasswordHistory[]
-  blacklistedTokens     BlacklistedToken[]
-  preferences           UserPreferences?
-  activityLogs          ActivityLog[]
-  verificationDocuments VerificationDocument[]
-  sessions              Session[]
-  passwordResetTokens   PasswordResetToken[]
-  loginHistory          LoginHistory[]
-  referrals             User[]                 @relation("Referrals")
-  referredBy            User?                  @relation("Referrals", fields: [referredById], references: [id])
+  properties              Property[]
+  buyerTransactions       Transaction[]            @relation("BuyerTransactions")
+  sellerTransactions      Transaction[]            @relation("SellerTransactions")
+  documents               Document[]
+  apiKeys                 ApiKey[]
+  passwordHistory         PasswordHistory[]
+  blacklistedTokens       BlacklistedToken[]
+  preferences             UserPreferences?
+  activityLogs            ActivityLog[]
+  verificationDocuments   VerificationDocument[]
+  sessions                Session[]
+  passwordResetTokens     PasswordResetToken[]
+  loginHistory            LoginHistory[]
+  fraudAlerts             FraudAlert[]             @relation("FraudAlertSubjectUser")
+  assignedFraudAlerts     FraudAlert[]             @relation("FraudAlertAssignedTo")
+  resolvedFraudAlerts     FraudAlert[]             @relation("FraudAlertResolvedBy")
+  fraudInvestigationNotes FraudInvestigationNote[]
+  referrals               User[]                   @relation("Referrals")
+  referredBy              User?                    @relation("Referrals", fields: [referredById], references: [id])
 
   @@index([email])
   @@index([role])
@@ -125,18 +154,18 @@ model User {
 }
 
 model ApiKey {
-  id         String    @id @default(uuid())
-  userId     String    @map("user_id")
-  name       String
-  keyPrefix  String    @map("key_prefix")
-  keyHash    String    @unique @map("key_hash")
-  permissions String[] @default([])
-  usageCount Int       @default(0) @map("usage_count")
-  lastUsedAt DateTime? @map("last_used_at")
-  expiresAt  DateTime? @map("expires_at")
-  revokedAt  DateTime? @map("revoked_at")
-  createdAt  DateTime  @default(now()) @map("created_at")
-  updatedAt  DateTime  @updatedAt @map("updated_at")
+  id          String    @id @default(uuid())
+  userId      String    @map("user_id")
+  name        String
+  keyPrefix   String    @map("key_prefix")
+  keyHash     String    @unique @map("key_hash")
+  permissions String[]  @default([])
+  usageCount  Int       @default(0) @map("usage_count")
+  lastUsedAt  DateTime? @map("last_used_at")
+  expiresAt   DateTime? @map("expires_at")
+  revokedAt   DateTime? @map("revoked_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -255,6 +284,7 @@ model Property {
   owner        User          @relation(fields: [ownerId], references: [id], onDelete: Cascade)
   transactions Transaction[]
   documents    Document[]
+  fraudAlerts  FraudAlert[]
 
   @@index([ownerId])
   @@index([status])
@@ -280,9 +310,10 @@ model Transaction {
   updatedAt       DateTime          @updatedAt @map("updated_at")
 
   // Relations
-  property Property @relation(fields: [propertyId], references: [id])
-  buyer    User     @relation("BuyerTransactions", fields: [buyerId], references: [id])
-  seller   User     @relation("SellerTransactions", fields: [sellerId], references: [id])
+  property    Property     @relation(fields: [propertyId], references: [id])
+  buyer       User         @relation("BuyerTransactions", fields: [buyerId], references: [id])
+  seller      User         @relation("SellerTransactions", fields: [sellerId], references: [id])
+  fraudAlerts FraudAlert[]
 
   @@index([propertyId])
   @@index([buyerId])
@@ -389,12 +420,69 @@ model Session {
   lastActivityAt  DateTime  @default(now()) @map("last_activity_at")
 
   // Relations
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  fraudAlerts FraudAlert[]
 
   @@index([userId])
   @@index([expiresAt])
   @@index([isRevoked])
   @@map("sessions")
+}
+
+model FraudAlert {
+  id              String        @id @default(uuid())
+  userId          String?       @map("user_id")
+  propertyId      String?       @map("property_id")
+  transactionId   String?       @map("transaction_id")
+  sessionId       String?       @map("session_id")
+  pattern         FraudPattern
+  severity        FraudSeverity
+  status          FraudStatus   @default(OPEN)
+  score           Int           @default(0)
+  title           String
+  description     String        @db.Text
+  evidence        Json?
+  autoBlocked     Boolean       @default(false) @map("auto_blocked")
+  firstDetectedAt DateTime      @default(now()) @map("first_detected_at")
+  lastDetectedAt  DateTime      @default(now()) @map("last_detected_at")
+  occurrenceCount Int           @default(1) @map("occurrence_count")
+  assignedToId    String?       @map("assigned_to_id")
+  resolvedById    String?       @map("resolved_by_id")
+  resolvedAt      DateTime?     @map("resolved_at")
+  createdAt       DateTime      @default(now()) @map("created_at")
+  updatedAt       DateTime      @updatedAt @map("updated_at")
+
+  user        User?                    @relation("FraudAlertSubjectUser", fields: [userId], references: [id], onDelete: SetNull)
+  property    Property?                @relation(fields: [propertyId], references: [id], onDelete: SetNull)
+  transaction Transaction?             @relation(fields: [transactionId], references: [id], onDelete: SetNull)
+  session     Session?                 @relation(fields: [sessionId], references: [id], onDelete: SetNull)
+  assignedTo  User?                    @relation("FraudAlertAssignedTo", fields: [assignedToId], references: [id], onDelete: SetNull)
+  resolvedBy  User?                    @relation("FraudAlertResolvedBy", fields: [resolvedById], references: [id], onDelete: SetNull)
+  notes       FraudInvestigationNote[]
+
+  @@index([status, severity])
+  @@index([userId, status])
+  @@index([propertyId, status])
+  @@index([pattern, status])
+  @@index([lastDetectedAt])
+  @@map("fraud_alerts")
+}
+
+model FraudInvestigationNote {
+  id        String   @id @default(uuid())
+  alertId   String   @map("alert_id")
+  actorId   String?  @map("actor_id")
+  action    String?
+  note      String   @db.Text
+  metadata  Json?
+  createdAt DateTime @default(now()) @map("created_at")
+
+  alert FraudAlert @relation(fields: [alertId], references: [id], onDelete: Cascade)
+  actor User?      @relation(fields: [actorId], references: [id], onDelete: SetNull)
+
+  @@index([alertId, createdAt])
+  @@index([actorId])
+  @@map("fraud_investigation_notes")
 }
 
 // Verification Document model

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -7,11 +7,15 @@ import { AuthUserPayload } from '../auth/types/auth-user.type';
 import { UserRole } from '../types/prisma.types';
 import { AdminService } from './admin.service';
 import {
+  AddFraudInvestigationNoteDto,
   AdminUpdateUserDto,
   AdminUsersQueryDto,
+  BlockFraudUserDto,
   BulkModerationDto,
   FlagPropertyDto,
+  FraudAlertsQueryDto,
   ModerationQueueQueryDto,
+  ReviewFraudAlertDto,
   TransactionMonitoringQueryDto,
 } from './dto/admin.dto';
 
@@ -79,5 +83,57 @@ export class AdminController {
   @Get('transactions/monitoring/summary')
   monitorTransactionsSummary() {
     return this.adminService.transactionMonitoringSummary();
+  }
+
+  @Get('fraud/alerts')
+  listFraudAlerts(@Query() query: FraudAlertsQueryDto) {
+    return this.adminService.listFraudAlerts(query);
+  }
+
+  @Get('fraud/alerts/summary')
+  getFraudAlertsSummary() {
+    return this.adminService.getFraudAlertsSummary();
+  }
+
+  @Get('fraud/alerts/:id')
+  getFraudAlertDetails(@Param('id') alertId: string) {
+    return this.adminService.getFraudAlertDetails(alertId);
+  }
+
+  @Patch('fraud/alerts/:id')
+  reviewFraudAlert(
+    @Param('id') alertId: string,
+    @Body() payload: ReviewFraudAlertDto,
+    @CurrentUser() user: AuthUserPayload,
+  ) {
+    return this.adminService.reviewFraudAlert(alertId, payload, user.sub);
+  }
+
+  @Post('fraud/alerts/:id/notes')
+  addFraudAlertNote(
+    @Param('id') alertId: string,
+    @Body() payload: AddFraudInvestigationNoteDto,
+    @CurrentUser() user: AuthUserPayload,
+  ) {
+    return this.adminService.addFraudAlertNote(alertId, payload, user.sub);
+  }
+
+  @Post('fraud/alerts/:id/block-user')
+  blockFraudUser(
+    @Param('id') alertId: string,
+    @Body() payload: BlockFraudUserDto,
+    @CurrentUser() user: AuthUserPayload,
+  ) {
+    return this.adminService.blockFraudUser(alertId, user.sub, payload);
+  }
+
+  @Post('fraud/users/:id/scan')
+  scanUserForFraud(@Param('id') userId: string, @CurrentUser() user: AuthUserPayload) {
+    return this.adminService.scanUserForFraud(userId, user.sub);
+  }
+
+  @Post('fraud/properties/:id/scan')
+  scanPropertyForFraud(@Param('id') propertyId: string, @CurrentUser() user: AuthUserPayload) {
+    return this.adminService.scanPropertyForFraud(propertyId, user.sub);
   }
 }

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AdminController } from './admin.controller';
 import { AdminService } from './admin.service';
 import { PrismaModule } from '../database/prisma.module';
+import { FraudModule } from '../fraud/fraud.module';
 
 @Module({
-  imports: [PrismaModule],
+  imports: [PrismaModule, FraudModule],
   controllers: [AdminController],
   providers: [AdminService],
   exports: [AdminService],

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,18 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../database/prisma.service';
 import {
+  AddFraudInvestigationNoteDto,
   AdminUpdateUserDto,
   AdminUsersQueryDto,
+  BlockFraudUserDto,
   BulkModerationAction,
   BulkModerationDto,
+  FraudAlertsQueryDto,
   ModerationQueueQueryDto,
+  ReviewFraudAlertDto,
   TransactionMonitoringQueryDto,
 } from './dto/admin.dto';
 import { PropertyStatus } from '../types/prisma.types';
+import { FraudService } from '../fraud/fraud.service';
 
 @Injectable()
 export class AdminService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly fraudService: FraudService,
+  ) {}
 
   async getDashboard() {
     const [totalUsers, blockedUsers, totalProperties, pendingProperties, activeProperties] =
@@ -289,5 +297,37 @@ export class AdminService {
       failed,
       totalCompletedValue: aggregateValue._sum.amount ?? 0,
     };
+  }
+
+  async listFraudAlerts(query: FraudAlertsQueryDto) {
+    return this.fraudService.listAlerts(query);
+  }
+
+  async getFraudAlertsSummary() {
+    return this.fraudService.getAlertSummary();
+  }
+
+  async getFraudAlertDetails(alertId: string) {
+    return this.fraudService.getAlertDetails(alertId);
+  }
+
+  async reviewFraudAlert(alertId: string, payload: ReviewFraudAlertDto, actorId: string) {
+    return this.fraudService.reviewAlert(alertId, payload, actorId);
+  }
+
+  async addFraudAlertNote(alertId: string, payload: AddFraudInvestigationNoteDto, actorId: string) {
+    return this.fraudService.addInvestigationNote(alertId, payload, actorId);
+  }
+
+  async blockFraudUser(alertId: string, actorId: string, payload?: BlockFraudUserDto) {
+    return this.fraudService.blockUserFromAlert(alertId, actorId, payload);
+  }
+
+  async scanUserForFraud(userId: string, actorId: string) {
+    return this.fraudService.runUserScan(userId, actorId);
+  }
+
+  async scanPropertyForFraud(propertyId: string, actorId: string) {
+    return this.fraudService.runPropertyScan(propertyId, actorId);
   }
 }

--- a/src/admin/dto/admin.dto.ts
+++ b/src/admin/dto/admin.dto.ts
@@ -11,6 +11,12 @@ import {
   Min,
 } from 'class-validator';
 import {
+  FraudAlertsQueryDto,
+  ReviewFraudAlertDto,
+  AddFraudInvestigationNoteDto,
+  BlockFraudUserDto,
+} from '../../fraud/dto/fraud.dto';
+import {
   PropertyStatus,
   TransactionStatus,
   TransactionType,
@@ -132,3 +138,10 @@ export class TransactionMonitoringQueryDto {
   @Max(100)
   limit: number = 20;
 }
+
+export {
+  AddFraudInvestigationNoteDto,
+  BlockFraudUserDto,
+  FraudAlertsQueryDto,
+  ReviewFraudAlertDto,
+};

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,6 +19,7 @@ import { IntegrationsModule } from './integrations/integrations.module';
 import { AppController } from './app.controller';
 import './common/common.types'; // Load registered enums
 import { AdminModule } from './admin/admin.module';
+import { FraudModule } from './fraud/fraud.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -46,6 +47,7 @@ import { AdminModule } from './admin/admin.module';
     TrustScoreModule,
     PropertiesModule,
     AdminModule,
+    FraudModule,
     DocumentsModule,
     IntegrationsModule,
   ],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -13,9 +13,10 @@ import { RolesGuard } from './guards/roles.guard';
 import { RateLimitGuard } from './guards/rate-limit.guard';
 import { RateLimitHeadersInterceptor } from './interceptors/rate-limit-headers.interceptor';
 import { RateLimitAdminController } from './controllers/rate-limit-admin.controller';
+import { FraudModule } from '../fraud/fraud.module';
 
 @Module({
-  imports: [PrismaModule, UsersModule, SessionsModule, EmailModule],
+  imports: [PrismaModule, UsersModule, SessionsModule, EmailModule, FraudModule],
   controllers: [AuthController, RateLimitAdminController],
   providers: [
     AuthService,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -44,6 +44,7 @@ import { AuthUserPayload } from './types/auth-user.type';
 
 import { LoginRateLimitService } from './login-rate-limit.service';
 import { UserRole } from '../types/prisma.types';
+import { FraudService } from '../fraud/fraud.service';
 
 type JwtPayload = {
   sub: string;
@@ -72,6 +73,7 @@ export class AuthService {
     private readonly configService: ConfigService,
     private readonly emailService: EmailService,
     private readonly rateLimitService: LoginRateLimitService,
+    private readonly fraudService: FraudService,
   ) {
     this.jwtSecret = this.configService.get<string>('JWT_SECRET') ?? 'propchain-access-secret';
     this.jwtRefreshSecret =
@@ -183,6 +185,8 @@ export class AuthService {
         userAgent,
       );
 
+      await this.fraudService.evaluateFailedLogin(data.email, ipAddress, userAgent);
+
       if (shouldLock) {
         const lockoutDuration = 30;
         await this.emailService.sendAccountLockedEmail(user.email, lockoutDuration).catch((err) => {
@@ -234,10 +238,25 @@ export class AuthService {
     // Record successful login
     await this.rateLimitService.recordSuccessfulAttempt(data.email, ipAddress, userAgent);
     await this.recordLoginHistory(user.id, ipAddress, userAgent);
+    await this.fraudService.evaluateSuccessfulLogin(user.id, ipAddress, userAgent);
 
-    const tokens = await this.issueTokenPair(user);
+    const refreshedUser = await this.prisma.user.findUnique({
+      where: { id: user.id },
+    });
+
+    if (!refreshedUser) {
+      throw new UnauthorizedException('User no longer exists');
+    }
+
+    if (refreshedUser.isBlocked) {
+      throw new UnauthorizedException(
+        'Your account has been blocked after a fraud review. Please contact support.',
+      );
+    }
+
+    const tokens = await this.issueTokenPair(refreshedUser, undefined, ipAddress, userAgent);
     return {
-      user: sanitizeUser(user),
+      user: sanitizeUser(refreshedUser),
       ...tokens,
     };
   }
@@ -258,6 +277,7 @@ export class AuthService {
       // TOKEN REUSE DETECTED! This is a potential attack
       // Mark the reuse and invalidate the entire token family
       await this.handleTokenReuse(blacklistedToken, payload.jti, ipAddress, userAgent);
+      await this.fraudService.handleTokenReuse(payload.sub, payload.jti, ipAddress, userAgent);
 
       this.logger.error(
         `Refresh token reuse detected for user ${payload.sub} (JTI: ${payload.jti}, Family: ${payload.family}). IP: ${ipAddress}`,
@@ -295,7 +315,7 @@ export class AuthService {
     });
 
     // Issue new token pair with SAME family ID
-    const tokens = await this.issueTokenPair(user, payload.family);
+    const tokens = await this.issueTokenPair(user, payload.family, ipAddress, userAgent);
 
     this.logger.log(
       `Token rotated for user ${user.id} (${user.email}). Family: ${payload.family}. IP: ${ipAddress}`,

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -8,6 +8,15 @@ export interface EmailOptions {
   text?: string;
 }
 
+export interface FraudAlertEmailPayload {
+  alertId: string;
+  pattern: string;
+  severity: string;
+  title: string;
+  description: string;
+  userEmail?: string | null;
+}
+
 @Injectable()
 export class EmailService {
   constructor(private readonly configService: ConfigService) {}
@@ -79,6 +88,36 @@ export class EmailService {
     };
 
     await this.sendEmail(emailOptions);
+  }
+
+  async sendFraudAlertEmail(recipients: string[], payload: FraudAlertEmailPayload): Promise<void> {
+    await Promise.all(
+      recipients.map((recipient) =>
+        this.sendEmail({
+          to: recipient,
+          subject: `[Fraud Alert][${payload.severity}] ${payload.title}`,
+          html: `
+            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+              <h2 style="color: #d9534f;">Fraud Alert Triggered</h2>
+              <p><strong>Alert ID:</strong> ${payload.alertId}</p>
+              <p><strong>Pattern:</strong> ${payload.pattern}</p>
+              <p><strong>Severity:</strong> ${payload.severity}</p>
+              <p><strong>User:</strong> ${payload.userEmail ?? 'Unknown'}</p>
+              <p><strong>Summary:</strong> ${payload.description}</p>
+            </div>
+          `,
+          text: `
+Fraud Alert Triggered
+
+Alert ID: ${payload.alertId}
+Pattern: ${payload.pattern}
+Severity: ${payload.severity}
+User: ${payload.userEmail ?? 'Unknown'}
+Summary: ${payload.description}
+          `.trim(),
+        }),
+      ),
+    );
   }
 
   private async sendEmail(options: EmailOptions): Promise<void> {

--- a/src/fraud/dto/fraud.dto.ts
+++ b/src/fraud/dto/fraud.dto.ts
@@ -1,0 +1,91 @@
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import { FraudPattern, FraudSeverity, FraudStatus } from '../../types/prisma.types';
+
+export class FraudAlertsQueryDto {
+  @IsOptional()
+  @IsEnum(FraudStatus)
+  status?: FraudStatus;
+
+  @IsOptional()
+  @IsEnum(FraudSeverity)
+  severity?: FraudSeverity;
+
+  @IsOptional()
+  @IsEnum(FraudPattern)
+  pattern?: FraudPattern;
+
+  @IsOptional()
+  @IsUUID('4')
+  userId?: string;
+
+  @IsOptional()
+  @IsUUID('4')
+  assignedToId?: string;
+
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  autoBlocked?: boolean;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+}
+
+export class ReviewFraudAlertDto {
+  @IsOptional()
+  @IsEnum(FraudStatus)
+  status?: FraudStatus;
+
+  @IsOptional()
+  @IsUUID('4')
+  assignedToId?: string;
+
+  @IsOptional()
+  @IsString()
+  note?: string;
+
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  blockUser?: boolean;
+}
+
+export class AddFraudInvestigationNoteDto {
+  @IsString()
+  note!: string;
+
+  @IsOptional()
+  @IsString()
+  action?: string;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}
+
+export class BlockFraudUserDto {
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/fraud/fraud.module.ts
+++ b/src/fraud/fraud.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { PrismaModule } from '../database/prisma.module';
+import { EmailModule } from '../email/email.module';
+import { FraudService } from './fraud.service';
+
+@Module({
+  imports: [ConfigModule, PrismaModule, EmailModule],
+  providers: [FraudService],
+  exports: [FraudService],
+})
+export class FraudModule {}

--- a/src/fraud/fraud.service.spec.ts
+++ b/src/fraud/fraud.service.spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { FraudService } from './fraud.service';
+import { PrismaService } from '../database/prisma.service';
+import { EmailService } from '../email/email.service';
+import { FraudPattern, FraudSeverity } from '../types/prisma.types';
+
+describe('FraudService', () => {
+  let service: FraudService;
+
+  const mockPrismaService = {
+    user: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    loginAttempt: {
+      count: jest.fn(),
+    },
+    loginHistory: {
+      findMany: jest.fn(),
+      count: jest.fn(),
+    },
+    property: {
+      findUnique: jest.fn(),
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+    fraudAlert: {
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      count: jest.fn(),
+      groupBy: jest.fn(),
+    },
+    fraudInvestigationNote: {
+      create: jest.fn(),
+    },
+    activityLog: {
+      create: jest.fn(),
+    },
+    session: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+  } as any;
+
+  const mockEmailService = {
+    sendFraudAlertEmail: jest.fn(),
+  } as any;
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      if (key === 'FRAUD_ALERT_RECIPIENTS') {
+        return 'fraud@propchain.test';
+      }
+
+      return undefined;
+    }),
+  } as any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FraudService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: EmailService, useValue: mockEmailService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<FraudService>(FraudService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('creates a failed-login alert once the threshold is crossed', async () => {
+    mockPrismaService.user.findUnique.mockResolvedValue({
+      id: 'user-1',
+      email: 'user@example.com',
+    });
+    mockPrismaService.loginAttempt.count.mockResolvedValue(6);
+
+    const createOrUpdateAlertSpy = jest
+      .spyOn(service as any, 'createOrUpdateAlert')
+      .mockResolvedValue({ id: 'alert-1' });
+
+    const result = await service.evaluateFailedLogin('user@example.com', '10.0.0.1', 'Mozilla');
+
+    expect(result).toEqual({ id: 'alert-1' });
+    expect(createOrUpdateAlertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        pattern: FraudPattern.EXCESSIVE_FAILED_LOGINS,
+        severity: FraudSeverity.MEDIUM,
+      }),
+    );
+  });
+
+  it('flags suspicious property patterns for rapid duplicate high-value listings', async () => {
+    mockPrismaService.property.findUnique.mockResolvedValue({
+      id: 'property-1',
+      ownerId: 'owner-1',
+      address: '1 Main St',
+      city: 'Austin',
+      state: 'TX',
+      zipCode: '78701',
+      country: 'USA',
+      price: 1500000,
+      owner: {
+        id: 'owner-1',
+        createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+      },
+    });
+    mockPrismaService.property.count.mockResolvedValue(3);
+    mockPrismaService.property.findMany.mockResolvedValue([
+      {
+        id: 'property-2',
+        ownerId: 'owner-2',
+        title: 'Duplicate listing',
+        createdAt: new Date(),
+      },
+    ]);
+
+    const createOrUpdateAlertSpy = jest
+      .spyOn(service as any, 'createOrUpdateAlert')
+      .mockImplementation(async (payload: any) => payload);
+
+    const alerts = await service.evaluatePropertyCreated('property-1');
+
+    expect(alerts).toHaveLength(3);
+    expect(createOrUpdateAlertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        propertyId: 'property-1',
+        pattern: FraudPattern.RAPID_PROPERTY_LISTINGS,
+      }),
+    );
+    expect(createOrUpdateAlertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        propertyId: 'property-1',
+        pattern: FraudPattern.DUPLICATE_PROPERTY_ADDRESS,
+      }),
+    );
+    expect(createOrUpdateAlertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        propertyId: 'property-1',
+        pattern: FraudPattern.HIGH_VALUE_NEW_ACCOUNT_LISTING,
+      }),
+    );
+  });
+
+  it('auto-blocks a user when a critical alert is created with enforcement enabled', async () => {
+    jest.spyOn(service as any, 'findOpenAlert').mockResolvedValue(null);
+    jest.spyOn(service as any, 'notifySecurityTeam').mockResolvedValue(undefined);
+    const blockUserForFraudSpy = jest
+      .spyOn(service as any, 'blockUserForFraud')
+      .mockResolvedValue(undefined);
+
+    mockPrismaService.fraudAlert.create.mockResolvedValue({
+      id: 'alert-1',
+      pattern: FraudPattern.TOKEN_REUSE,
+      severity: FraudSeverity.CRITICAL,
+      title: 'Refresh token reuse detected',
+      description: 'Detected token reuse',
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+      },
+    });
+
+    await (service as any).createOrUpdateAlert({
+      userId: 'user-1',
+      pattern: FraudPattern.TOKEN_REUSE,
+      severity: FraudSeverity.CRITICAL,
+      score: 100,
+      title: 'Refresh token reuse detected',
+      description: 'Detected token reuse',
+      evidence: {
+        reusedJti: 'token-1',
+      },
+      autoBlockUser: true,
+    });
+
+    expect(mockPrismaService.fraudAlert.create).toHaveBeenCalled();
+    expect(blockUserForFraudSpy).toHaveBeenCalledWith(
+      'user-1',
+      'alert-1',
+      'user-1',
+      'Automatically blocked by the fraud detection engine.',
+    );
+  });
+});

--- a/src/fraud/fraud.service.ts
+++ b/src/fraud/fraud.service.ts
@@ -1,0 +1,959 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../database/prisma.service';
+import { EmailService } from '../email/email.service';
+import {
+  AddFraudInvestigationNoteDto,
+  BlockFraudUserDto,
+  FraudAlertsQueryDto,
+  ReviewFraudAlertDto,
+} from './dto/fraud.dto';
+import { FraudPattern, FraudSeverity, FraudStatus } from '../types/prisma.types';
+
+type DetectionSubject = {
+  userId?: string;
+  propertyId?: string;
+  transactionId?: string;
+  sessionId?: string;
+};
+
+type AlertPayload = DetectionSubject & {
+  pattern: FraudPattern;
+  severity: FraudSeverity;
+  score: number;
+  title: string;
+  description: string;
+  evidence?: Prisma.InputJsonValue;
+  autoBlockUser?: boolean;
+};
+
+type InvestigationContext = {
+  recentSessions: unknown[];
+  recentLogins: unknown[];
+  recentActivity: unknown[];
+  relatedAlerts: unknown[];
+  duplicateProperties: unknown[];
+  sharedIpAccounts: unknown[];
+};
+
+@Injectable()
+export class FraudService {
+  private readonly logger = new Logger(FraudService.name);
+  private readonly fraudAlertRecipients: string[];
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly emailService: EmailService,
+    private readonly configService: ConfigService,
+  ) {
+    this.fraudAlertRecipients = (this.configService.get<string>('FRAUD_ALERT_RECIPIENTS') ?? '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean);
+  }
+
+  async evaluateFailedLogin(email: string, ipAddress?: string, userAgent?: string) {
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return null;
+    }
+
+    const windowStart = new Date(Date.now() - 30 * 60 * 1000);
+    const failedAttempts = await this.prisma.loginAttempt.count({
+      where: {
+        email,
+        success: false,
+        attemptTime: { gte: windowStart },
+      },
+    });
+
+    if (failedAttempts < 5) {
+      return null;
+    }
+
+    const severity = failedAttempts >= 10 ? FraudSeverity.HIGH : FraudSeverity.MEDIUM;
+
+    return this.createOrUpdateAlert({
+      userId: user.id,
+      pattern: FraudPattern.EXCESSIVE_FAILED_LOGINS,
+      severity,
+      score: failedAttempts >= 10 ? 82 : 58,
+      title: 'Repeated failed login attempts detected',
+      description: `The account recorded ${failedAttempts} failed login attempts in the last 30 minutes.`,
+      evidence: {
+        email,
+        ipAddress: ipAddress ?? null,
+        userAgent: userAgent ?? null,
+        failedAttempts,
+        windowMinutes: 30,
+      },
+    });
+  }
+
+  async evaluateSuccessfulLogin(userId: string, ipAddress?: string, userAgent?: string) {
+    const generatedAlerts: unknown[] = [];
+    const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const [recentLogins, matchingLoginCount, sharedIpAccounts] = await Promise.all([
+      this.prisma.loginHistory.findMany({
+        where: { userId, timestamp: { gte: windowStart } },
+        orderBy: { timestamp: 'desc' },
+        take: 20,
+      }),
+      ipAddress || userAgent
+        ? this.prisma.loginHistory.count({
+            where: {
+              userId,
+              ...(ipAddress ? { ipAddress } : {}),
+              ...(userAgent ? { userAgent } : {}),
+            },
+          })
+        : Promise.resolve(0),
+      ipAddress
+        ? this.prisma.loginHistory.findMany({
+            where: {
+              ipAddress,
+              timestamp: { gte: windowStart },
+            },
+            select: { userId: true },
+            distinct: ['userId'],
+          })
+        : Promise.resolve([]),
+    ]);
+
+    const distinctIps = new Set(
+      recentLogins
+        .map((entry) => entry.ipAddress)
+        .filter((value): value is string => Boolean(value)),
+    ).size;
+
+    if (distinctIps >= 4) {
+      generatedAlerts.push(
+        await this.createOrUpdateAlert({
+          userId,
+          pattern: FraudPattern.MULTIPLE_IPS_FOR_ACCOUNT,
+          severity: distinctIps >= 6 ? FraudSeverity.HIGH : FraudSeverity.MEDIUM,
+          score: distinctIps >= 6 ? 84 : 60,
+          title: 'Account accessed from multiple IP addresses',
+          description: `The account used ${distinctIps} distinct IP addresses in the last 24 hours.`,
+          evidence: {
+            ipAddress: ipAddress ?? null,
+            userAgent: userAgent ?? null,
+            distinctIps,
+            windowHours: 24,
+            recentIps: Array.from(
+              new Set(
+                recentLogins
+                  .map((entry) => entry.ipAddress)
+                  .filter((value): value is string => Boolean(value)),
+              ),
+            ).slice(0, 10),
+          },
+        }),
+      );
+    }
+
+    if (recentLogins.length > 1 && matchingLoginCount === 1 && (ipAddress || userAgent)) {
+      generatedAlerts.push(
+        await this.createOrUpdateAlert({
+          userId,
+          pattern: FraudPattern.NEW_DEVICE_LOGIN,
+          severity: FraudSeverity.LOW,
+          score: 24,
+          title: 'Login from a new device or location',
+          description:
+            'A successful login came from a device or IP address not previously seen for this account.',
+          evidence: {
+            ipAddress: ipAddress ?? null,
+            userAgent: userAgent ?? null,
+            recentLoginCount: recentLogins.length,
+          },
+        }),
+      );
+    }
+
+    if (ipAddress && sharedIpAccounts.length >= 3) {
+      generatedAlerts.push(
+        await this.createOrUpdateAlert({
+          userId,
+          pattern: FraudPattern.SHARED_IP_MULTIPLE_ACCOUNTS,
+          severity: sharedIpAccounts.length >= 5 ? FraudSeverity.CRITICAL : FraudSeverity.HIGH,
+          score: sharedIpAccounts.length >= 5 ? 95 : 78,
+          title: 'Same IP address used across multiple accounts',
+          description: `The login IP ${ipAddress} was used by ${sharedIpAccounts.length} accounts in the last 24 hours.`,
+          evidence: {
+            ipAddress,
+            userAgent: userAgent ?? null,
+            accountIds: sharedIpAccounts.map((entry) => entry.userId),
+            distinctAccounts: sharedIpAccounts.length,
+            windowHours: 24,
+          },
+          autoBlockUser: sharedIpAccounts.length >= 5,
+        }),
+      );
+    }
+
+    return generatedAlerts.filter(Boolean);
+  }
+
+  async handleTokenReuse(
+    userId: string,
+    reusedJti: string,
+    ipAddress?: string,
+    userAgent?: string,
+  ) {
+    const session = await this.prisma.session.findFirst({
+      where: {
+        OR: [{ refreshTokenJti: reusedJti }, { accessTokenJti: reusedJti }],
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return this.createOrUpdateAlert({
+      userId,
+      sessionId: session?.id,
+      pattern: FraudPattern.TOKEN_REUSE,
+      severity: FraudSeverity.CRITICAL,
+      score: 100,
+      title: 'Refresh token reuse detected',
+      description:
+        'A previously blacklisted token was presented again, which indicates possible token theft or replay.',
+      evidence: {
+        reusedJti,
+        ipAddress: ipAddress ?? null,
+        userAgent: userAgent ?? null,
+        sessionId: session?.id ?? null,
+      },
+      autoBlockUser: true,
+    });
+  }
+
+  async evaluatePropertyCreated(propertyId: string) {
+    const property = await this.prisma.property.findUnique({
+      where: { id: propertyId },
+      include: {
+        owner: true,
+      },
+    });
+
+    if (!property) {
+      throw new NotFoundException('Property not found');
+    }
+
+    const generatedAlerts: unknown[] = [];
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const normalizedAddress = this.normalizeAddress(
+      `${property.address} ${property.city} ${property.state} ${property.zipCode} ${property.country}`,
+    );
+
+    const [rapidListingsCount, duplicateListings] = await Promise.all([
+      this.prisma.property.count({
+        where: {
+          ownerId: property.ownerId,
+          createdAt: { gte: oneHourAgo },
+        },
+      }),
+      this.prisma.property.findMany({
+        where: {
+          id: { not: property.id },
+          address: { equals: property.address, mode: 'insensitive' },
+          city: { equals: property.city, mode: 'insensitive' },
+          state: { equals: property.state, mode: 'insensitive' },
+          zipCode: property.zipCode,
+        },
+        select: {
+          id: true,
+          ownerId: true,
+          title: true,
+          createdAt: true,
+        },
+        take: 10,
+      }),
+    ]);
+
+    if (rapidListingsCount >= 3) {
+      generatedAlerts.push(
+        await this.createOrUpdateAlert({
+          userId: property.ownerId,
+          propertyId: property.id,
+          pattern: FraudPattern.RAPID_PROPERTY_LISTINGS,
+          severity: rapidListingsCount >= 5 ? FraudSeverity.HIGH : FraudSeverity.MEDIUM,
+          score: rapidListingsCount >= 5 ? 80 : 55,
+          title: 'Rapid listing creation detected',
+          description: `The owner created ${rapidListingsCount} property listings within the last hour.`,
+          evidence: {
+            propertyId: property.id,
+            ownerId: property.ownerId,
+            rapidListingsCount,
+            windowMinutes: 60,
+          },
+        }),
+      );
+    }
+
+    const duplicatesByOtherOwners = duplicateListings.filter(
+      (listing) => listing.ownerId !== property.ownerId,
+    );
+
+    if (duplicatesByOtherOwners.length > 0) {
+      generatedAlerts.push(
+        await this.createOrUpdateAlert({
+          userId: property.ownerId,
+          propertyId: property.id,
+          pattern: FraudPattern.DUPLICATE_PROPERTY_ADDRESS,
+          severity: duplicatesByOtherOwners.length >= 2 ? FraudSeverity.HIGH : FraudSeverity.MEDIUM,
+          score: duplicatesByOtherOwners.length >= 2 ? 76 : 57,
+          title: 'Duplicate property address detected',
+          description: 'The same property address appears on listings owned by different accounts.',
+          evidence: {
+            normalizedAddress,
+            duplicateListings: duplicatesByOtherOwners,
+          },
+        }),
+      );
+    }
+
+    const accountAgeDays = Math.floor(
+      (Date.now() - new Date(property.owner.createdAt).getTime()) / (1000 * 60 * 60 * 24),
+    );
+    const propertyPrice = Number(property.price);
+
+    if (accountAgeDays <= 14 && propertyPrice >= 1_000_000) {
+      generatedAlerts.push(
+        await this.createOrUpdateAlert({
+          userId: property.ownerId,
+          propertyId: property.id,
+          pattern: FraudPattern.HIGH_VALUE_NEW_ACCOUNT_LISTING,
+          severity: FraudSeverity.HIGH,
+          score: 85,
+          title: 'High-value listing from a new account',
+          description: 'A recently created account submitted a high-value property listing.',
+          evidence: {
+            propertyId: property.id,
+            ownerId: property.ownerId,
+            accountAgeDays,
+            price: propertyPrice,
+            thresholdPrice: 1000000,
+            thresholdAgeDays: 14,
+          },
+        }),
+      );
+    }
+
+    return generatedAlerts.filter(Boolean);
+  }
+
+  async listAlerts(query: FraudAlertsQueryDto) {
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 20;
+    const skip = (page - 1) * limit;
+
+    const where: Prisma.FraudAlertWhereInput = {
+      status: query.status,
+      severity: query.severity,
+      pattern: query.pattern,
+      userId: query.userId,
+      assignedToId: query.assignedToId,
+      autoBlocked: query.autoBlocked,
+    };
+
+    const [items, total] = await Promise.all([
+      this.prisma.fraudAlert.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy: [{ severity: 'desc' }, { lastDetectedAt: 'desc' }],
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+              isBlocked: true,
+            },
+          },
+          property: {
+            select: {
+              id: true,
+              title: true,
+              address: true,
+              city: true,
+              state: true,
+            },
+          },
+          assignedTo: {
+            select: {
+              id: true,
+              email: true,
+              firstName: true,
+              lastName: true,
+            },
+          },
+        },
+      }),
+      this.prisma.fraudAlert.count({ where }),
+    ]);
+
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  async getAlertSummary() {
+    const [open, investigating, resolved, dismissed, autoBlocked, critical, high] =
+      await Promise.all([
+        this.prisma.fraudAlert.count({ where: { status: FraudStatus.OPEN } }),
+        this.prisma.fraudAlert.count({ where: { status: FraudStatus.INVESTIGATING } }),
+        this.prisma.fraudAlert.count({ where: { status: FraudStatus.RESOLVED } }),
+        this.prisma.fraudAlert.count({ where: { status: FraudStatus.DISMISSED } }),
+        this.prisma.fraudAlert.count({ where: { autoBlocked: true } }),
+        this.prisma.fraudAlert.count({ where: { severity: FraudSeverity.CRITICAL } }),
+        this.prisma.fraudAlert.count({ where: { severity: FraudSeverity.HIGH } }),
+      ]);
+
+    const byPattern = await this.prisma.fraudAlert.groupBy({
+      by: ['pattern'],
+      _count: { _all: true },
+      orderBy: {
+        _count: {
+          pattern: 'desc',
+        },
+      },
+    });
+
+    return {
+      statuses: { open, investigating, resolved, dismissed },
+      severity: { critical, high },
+      autoBlocked,
+      byPattern: byPattern.map((entry) => ({
+        pattern: entry.pattern,
+        count: entry._count._all,
+      })),
+    };
+  }
+
+  async getAlertDetails(alertId: string) {
+    const alert = await this.prisma.fraudAlert.findUnique({
+      where: { id: alertId },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            isBlocked: true,
+            createdAt: true,
+            trustScore: true,
+          },
+        },
+        property: {
+          select: {
+            id: true,
+            title: true,
+            address: true,
+            city: true,
+            state: true,
+            zipCode: true,
+            price: true,
+            status: true,
+            ownerId: true,
+          },
+        },
+        transaction: true,
+        session: {
+          select: {
+            id: true,
+            ipAddress: true,
+            userAgent: true,
+            createdAt: true,
+            lastActivityAt: true,
+            isRevoked: true,
+          },
+        },
+        assignedTo: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        resolvedBy: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+        notes: {
+          orderBy: { createdAt: 'desc' },
+          include: {
+            actor: {
+              select: {
+                id: true,
+                email: true,
+                firstName: true,
+                lastName: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!alert) {
+      throw new NotFoundException('Fraud alert not found');
+    }
+
+    const investigationContext = await this.buildInvestigationContext(alert);
+    return {
+      ...alert,
+      investigationContext,
+    };
+  }
+
+  async reviewAlert(alertId: string, payload: ReviewFraudAlertDto, actorId: string) {
+    const alert = await this.ensureAlertExists(alertId);
+
+    const nextStatus =
+      payload.status ??
+      (payload.note || payload.assignedToId ? FraudStatus.INVESTIGATING : alert.status);
+
+    const updated = await this.prisma.fraudAlert.update({
+      where: { id: alertId },
+      data: {
+        status: nextStatus,
+        assignedToId: payload.assignedToId ?? alert.assignedToId,
+        resolvedAt:
+          nextStatus === FraudStatus.RESOLVED || nextStatus === FraudStatus.DISMISSED
+            ? new Date()
+            : null,
+        resolvedById:
+          nextStatus === FraudStatus.RESOLVED || nextStatus === FraudStatus.DISMISSED
+            ? actorId
+            : null,
+      },
+    });
+
+    if (payload.note) {
+      await this.addInvestigationNote(alertId, { note: payload.note, action: 'REVIEWED' }, actorId);
+    }
+
+    if (payload.blockUser && alert.userId) {
+      await this.blockUserForFraud(alert.userId, alertId, actorId, 'Blocked during fraud review.');
+    }
+
+    return this.getAlertDetails(updated.id);
+  }
+
+  async addInvestigationNote(
+    alertId: string,
+    payload: AddFraudInvestigationNoteDto,
+    actorId: string,
+  ) {
+    await this.ensureAlertExists(alertId);
+
+    return this.prisma.fraudInvestigationNote.create({
+      data: {
+        alertId,
+        actorId,
+        action: payload.action,
+        note: payload.note,
+        metadata: payload.metadata as Prisma.InputJsonValue | undefined,
+      },
+      include: {
+        actor: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      },
+    });
+  }
+
+  async blockUserFromAlert(alertId: string, actorId: string, payload?: BlockFraudUserDto) {
+    const alert = await this.ensureAlertExists(alertId);
+    if (!alert.userId) {
+      throw new NotFoundException('Fraud alert is not linked to a user');
+    }
+
+    await this.blockUserForFraud(
+      alert.userId,
+      alertId,
+      actorId,
+      payload?.reason ?? 'User blocked from fraud investigation workflow.',
+    );
+
+    return this.getAlertDetails(alertId);
+  }
+
+  async runUserScan(userId: string, actorId?: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, email: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const [failedLoginAlert, loginAlerts] = await Promise.all([
+      this.evaluateFailedLogin(user.email),
+      this.evaluateSuccessfulLogin(user.id),
+    ]);
+
+    if (actorId) {
+      await this.prisma.activityLog.create({
+        data: {
+          userId: actorId,
+          action: 'FRAUD_USER_SCAN_TRIGGERED',
+          entityType: 'USER',
+          entityId: userId,
+          description: `Manual fraud scan executed for user ${userId}.`,
+        },
+      });
+    }
+
+    return {
+      userId,
+      generatedAlerts: [failedLoginAlert, ...loginAlerts].filter(Boolean),
+    };
+  }
+
+  async runPropertyScan(propertyId: string, actorId?: string) {
+    const property = await this.prisma.property.findUnique({
+      where: { id: propertyId },
+      select: { id: true },
+    });
+
+    if (!property) {
+      throw new NotFoundException('Property not found');
+    }
+
+    const generatedAlerts = await this.evaluatePropertyCreated(propertyId);
+
+    if (actorId) {
+      await this.prisma.activityLog.create({
+        data: {
+          userId: actorId,
+          action: 'FRAUD_PROPERTY_SCAN_TRIGGERED',
+          entityType: 'PROPERTY',
+          entityId: propertyId,
+          description: `Manual fraud scan executed for property ${propertyId}.`,
+        },
+      });
+    }
+
+    return {
+      propertyId,
+      generatedAlerts,
+    };
+  }
+
+  private async createOrUpdateAlert(payload: AlertPayload) {
+    const existingAlert = await this.findOpenAlert(payload);
+    const now = new Date();
+
+    if (existingAlert) {
+      const updated = await this.prisma.fraudAlert.update({
+        where: { id: existingAlert.id },
+        data: {
+          severity:
+            this.severityRank(payload.severity) > this.severityRank(existingAlert.severity)
+              ? payload.severity
+              : existingAlert.severity,
+          score: Math.max(existingAlert.score, payload.score),
+          title: payload.title,
+          description: payload.description,
+          evidence: payload.evidence,
+          lastDetectedAt: now,
+          occurrenceCount: {
+            increment: 1,
+          },
+          autoBlocked: existingAlert.autoBlocked || Boolean(payload.autoBlockUser),
+        },
+      });
+
+      if (
+        payload.autoBlockUser &&
+        payload.userId &&
+        !existingAlert.autoBlocked &&
+        !existingAlert.userId?.startsWith('system-')
+      ) {
+        await this.blockUserForFraud(
+          payload.userId,
+          updated.id,
+          payload.userId,
+          'Automatically blocked after repeated fraud detections.',
+        );
+      }
+
+      return updated;
+    }
+
+    const created = await this.prisma.fraudAlert.create({
+      data: {
+        userId: payload.userId,
+        propertyId: payload.propertyId,
+        transactionId: payload.transactionId,
+        sessionId: payload.sessionId,
+        pattern: payload.pattern,
+        severity: payload.severity,
+        score: payload.score,
+        title: payload.title,
+        description: payload.description,
+        evidence: payload.evidence,
+        autoBlocked: Boolean(payload.autoBlockUser),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            email: true,
+            firstName: true,
+            lastName: true,
+            isBlocked: true,
+          },
+        },
+      },
+    });
+
+    if (payload.userId) {
+      await this.prisma.activityLog.create({
+        data: {
+          userId: payload.userId,
+          action: 'FRAUD_ALERT_CREATED',
+          entityType: payload.propertyId
+            ? 'PROPERTY'
+            : payload.transactionId
+              ? 'TRANSACTION'
+              : 'USER',
+          entityId: payload.propertyId ?? payload.transactionId ?? payload.userId,
+          description: payload.description,
+          metadata: payload.evidence,
+        },
+      });
+    }
+
+    await this.notifySecurityTeam(created);
+
+    if (payload.autoBlockUser && payload.userId) {
+      await this.blockUserForFraud(
+        payload.userId,
+        created.id,
+        payload.userId,
+        'Automatically blocked by the fraud detection engine.',
+      );
+    }
+
+    return created;
+  }
+
+  private async findOpenAlert(payload: AlertPayload) {
+    return this.prisma.fraudAlert.findFirst({
+      where: {
+        pattern: payload.pattern,
+        userId: payload.userId,
+        propertyId: payload.propertyId,
+        transactionId: payload.transactionId,
+        sessionId: payload.sessionId,
+        status: {
+          in: [FraudStatus.OPEN, FraudStatus.INVESTIGATING],
+        },
+      },
+      orderBy: { lastDetectedAt: 'desc' },
+    });
+  }
+
+  private async ensureAlertExists(alertId: string) {
+    const alert = await this.prisma.fraudAlert.findUnique({ where: { id: alertId } });
+    if (!alert) {
+      throw new NotFoundException('Fraud alert not found');
+    }
+    return alert;
+  }
+
+  private async buildInvestigationContext(alert: any): Promise<InvestigationContext> {
+    const userId = alert.userId;
+    const ipAddress = alert.session?.ipAddress ?? alert.evidence?.ipAddress;
+
+    if (!userId) {
+      return {
+        recentSessions: [],
+        recentLogins: [],
+        recentActivity: [],
+        relatedAlerts: [],
+        duplicateProperties: [],
+        sharedIpAccounts: [],
+      };
+    }
+
+    const [recentSessions, recentLogins, recentActivity, relatedAlerts, duplicateProperties] =
+      await Promise.all([
+        this.prisma.session.findMany({
+          where: { userId },
+          orderBy: { createdAt: 'desc' },
+          take: 10,
+        }),
+        this.prisma.loginHistory.findMany({
+          where: { userId },
+          orderBy: { timestamp: 'desc' },
+          take: 10,
+        }),
+        this.prisma.activityLog.findMany({
+          where: { userId },
+          orderBy: { createdAt: 'desc' },
+          take: 15,
+        }),
+        this.prisma.fraudAlert.findMany({
+          where: {
+            userId,
+            id: { not: alert.id },
+          },
+          orderBy: { lastDetectedAt: 'desc' },
+          take: 10,
+        }),
+        alert.propertyId
+          ? this.prisma.property.findMany({
+              where: {
+                id: { not: alert.propertyId },
+                address: { equals: alert.property?.address, mode: 'insensitive' },
+                city: { equals: alert.property?.city, mode: 'insensitive' },
+                state: { equals: alert.property?.state, mode: 'insensitive' },
+                zipCode: alert.property?.zipCode,
+              },
+              select: {
+                id: true,
+                ownerId: true,
+                title: true,
+                createdAt: true,
+              },
+            })
+          : Promise.resolve([]),
+      ]);
+
+    const sharedIpAccounts =
+      typeof ipAddress === 'string' && ipAddress.length > 0
+        ? await this.prisma.loginHistory.findMany({
+            where: { ipAddress },
+            orderBy: { timestamp: 'desc' },
+            take: 20,
+            distinct: ['userId'],
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  email: true,
+                  firstName: true,
+                  lastName: true,
+                  isBlocked: true,
+                },
+              },
+            },
+          })
+        : [];
+
+    return {
+      recentSessions,
+      recentLogins,
+      recentActivity,
+      relatedAlerts,
+      duplicateProperties,
+      sharedIpAccounts,
+    };
+  }
+
+  private async blockUserForFraud(
+    userId: string,
+    alertId: string,
+    actorId: string,
+    reason: string,
+  ) {
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        isBlocked: true,
+      },
+    });
+
+    await this.prisma.fraudAlert.update({
+      where: { id: alertId },
+      data: {
+        autoBlocked: true,
+      },
+    });
+
+    await this.prisma.activityLog.create({
+      data: {
+        userId,
+        action: 'USER_BLOCKED_FOR_FRAUD',
+        entityType: 'FRAUD_ALERT',
+        entityId: alertId,
+        description: reason,
+        metadata: {
+          actorId,
+        },
+      },
+    });
+
+    await this.prisma.fraudInvestigationNote.create({
+      data: {
+        alertId,
+        actorId,
+        action: 'USER_BLOCKED',
+        note: reason,
+        metadata: {
+          userId,
+        },
+      },
+    });
+  }
+
+  private async notifySecurityTeam(alert: any) {
+    if (this.fraudAlertRecipients.length === 0) {
+      return;
+    }
+
+    try {
+      await this.emailService.sendFraudAlertEmail(this.fraudAlertRecipients, {
+        alertId: alert.id,
+        pattern: alert.pattern,
+        severity: alert.severity,
+        title: alert.title,
+        description: alert.description,
+        userEmail: alert.user?.email,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to send fraud alert notification: ${error.message}`);
+    }
+  }
+
+  private severityRank(severity: FraudSeverity | string) {
+    switch (severity) {
+      case FraudSeverity.CRITICAL:
+        return 4;
+      case FraudSeverity.HIGH:
+        return 3;
+      case FraudSeverity.MEDIUM:
+        return 2;
+      case FraudSeverity.LOW:
+      default:
+        return 1;
+    }
+  }
+
+  private normalizeAddress(value: string) {
+    return value.trim().replace(/\s+/g, ' ').toUpperCase();
+  }
+}

--- a/src/properties/properties.module.ts
+++ b/src/properties/properties.module.ts
@@ -5,9 +5,10 @@ import { PrismaModule } from '../database/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { PropertiesResolver } from './properties.resolver';
 import { PubSub } from 'graphql-subscriptions';
+import { FraudModule } from '../fraud/fraud.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, FraudModule],
   controllers: [PropertiesController],
   providers: [
     PropertiesService,

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { Decimal } from '@prisma/client/runtime/library';
 import { PrismaService } from '../database/prisma.service';
 import { CreatePropertyDto, UpdatePropertyDto } from './dto/property.dto';
+import { FraudService } from '../fraud/fraud.service';
 
 interface FindAllParams {
   skip?: number;
@@ -12,12 +13,15 @@ interface FindAllParams {
 
 @Injectable()
 export class PropertiesService {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly fraudService: FraudService,
+  ) {}
 
   async create(createPropertyDto: CreatePropertyDto, ownerId: string) {
     const { price, squareFeet, lotSize, ...rest } = createPropertyDto;
 
-    return this.prisma.property.create({
+    const property = await this.prisma.property.create({
       data: {
         ...rest,
         price: new Decimal(price.toString()),
@@ -28,6 +32,10 @@ export class PropertiesService {
         },
       },
     });
+
+    await this.fraudService.evaluatePropertyCreated(property.id);
+
+    return property;
   }
 
   async findAll(params?: FindAllParams) {

--- a/src/types/prisma.types.ts
+++ b/src/types/prisma.types.ts
@@ -81,6 +81,31 @@ export enum TransactionStatus {
   FAILED = 'FAILED',
 }
 
+export enum FraudSeverity {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  CRITICAL = 'CRITICAL',
+}
+
+export enum FraudStatus {
+  OPEN = 'OPEN',
+  INVESTIGATING = 'INVESTIGATING',
+  RESOLVED = 'RESOLVED',
+  DISMISSED = 'DISMISSED',
+}
+
+export enum FraudPattern {
+  EXCESSIVE_FAILED_LOGINS = 'EXCESSIVE_FAILED_LOGINS',
+  SHARED_IP_MULTIPLE_ACCOUNTS = 'SHARED_IP_MULTIPLE_ACCOUNTS',
+  MULTIPLE_IPS_FOR_ACCOUNT = 'MULTIPLE_IPS_FOR_ACCOUNT',
+  NEW_DEVICE_LOGIN = 'NEW_DEVICE_LOGIN',
+  TOKEN_REUSE = 'TOKEN_REUSE',
+  RAPID_PROPERTY_LISTINGS = 'RAPID_PROPERTY_LISTINGS',
+  DUPLICATE_PROPERTY_ADDRESS = 'DUPLICATE_PROPERTY_ADDRESS',
+  HIGH_VALUE_NEW_ACCOUNT_LISTING = 'HIGH_VALUE_NEW_ACCOUNT_LISTING',
+}
+
 export namespace Prisma {
   export interface PropertyWhereInput extends Record<string, any> {}
   export interface PropertyOrderByWithRelationInput extends Record<string, any> {}


### PR DESCRIPTION
Implemented #416 end to end.

The backend now has a dedicated fraud subsystem centered in src/fraud/fraud.service.ts (line 1) with new Prisma models and a migration in prisma/schema.prisma (line 1) and migration.sql (line 1). It persists fraud alerts and investigation notes, detects patterns like excessive failed logins, shared IPs across accounts, multiple IPs on one account, new-device logins, token reuse, rapid listing bursts, duplicate property addresses, and high-value listings from very new accounts, and sends alert emails when FRAUD_ALERT_RECIPIENTS is configured.

Admin investigation tooling is wired through src/admin/admin.controller.ts (line 1) and src/admin/admin.service.ts (line 1): list alerts, summary view, alert details, review/update status, add notes, block a user from an alert, and manually scan users or properties. Enforcement is hooked into src/auth/auth.service.ts (line 1) and src/properties/properties.service.ts (line 1), so suspicious auth/property activity creates alerts automatically, and critical cases like token reuse can auto-block the

closes #416 