### PR TITLE
feat: add notification preferences (#370)

### DIFF
--- a/prisma/migrations/20260429020000_add_notification_preferences/migration.sql
+++ b/prisma/migrations/20260429020000_add_notification_preferences/migration.sql
@@ -1,0 +1,10 @@
+-- Migration: Add notification preferences fields to user_preferences (#370)
+-- Adds: notification_frequency, notification_event_types, quiet_hours, per_event_settings
+
+ALTER TABLE "user_preferences"
+  ADD COLUMN IF NOT EXISTS "notification_frequency"   TEXT         NOT NULL DEFAULT 'INSTANT',
+  ADD COLUMN IF NOT EXISTS "notification_event_types" TEXT[]       NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS "quiet_hours_enabled"      BOOLEAN      NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS "quiet_hours_start"        TEXT,
+  ADD COLUMN IF NOT EXISTS "quiet_hours_end"          TEXT,
+  ADD COLUMN IF NOT EXISTS "per_event_settings"       JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -514,6 +514,13 @@ model UserPreferences {
   propertyAlerts      Boolean  @default(true) @map("property_alerts")
   marketUpdates      Boolean  @default(true) @map("market_updates")
   theme              String   @default("light")
+  // Notification preferences (#370)
+  notificationFrequency  String   @default("INSTANT") @map("notification_frequency") // INSTANT | HOURLY | DAILY | WEEKLY
+  notificationEventTypes String[] @default([]) @map("notification_event_types")       // e.g. ["TRANSACTION_UPDATE","PROPERTY_ALERT","MARKET_UPDATE","DISPUTE","SYSTEM"]
+  quietHoursEnabled      Boolean  @default(false) @map("quiet_hours_enabled")
+  quietHoursStart        String?  @map("quiet_hours_start")  // "HH:MM" in user timezone
+  quietHoursEnd          String?  @map("quiet_hours_end")    // "HH:MM" in user timezone
+  perEventSettings       Json?    @map("per_event_settings") // fine-grained per-event channel overrides
   createdAt          DateTime @default(now()) @map("created_at")
   updatedAt          DateTime @updatedAt @map("updated_at")
 

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,12 +1,14 @@
+import { Module } from '@nestjs/common';
 import { NotificationsGateway } from './notifications.gateway';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
 import { SmsService } from './sms.service';
 import { PrismaModule } from '../database/prisma.module';
 import { EmailModule } from '../email/email.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [PrismaModule, EmailModule],
+  imports: [PrismaModule, EmailModule, UsersModule],
   controllers: [NotificationsController],
   providers: [NotificationsGateway, NotificationsService, SmsService],
   exports: [NotificationsService, SmsService],

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../database/prisma.service';
 import { NotificationsGateway } from './notifications.gateway';
 import { EmailService } from '../email/email.service';
 import { SmsService } from './sms.service';
+import { UserPreferencesService } from '../users/user-preferences.service';
 import { Transaction, TransactionStatus, User } from '@prisma/client';
 
 @Injectable()
@@ -12,6 +13,7 @@ export class NotificationsService {
     private gateway: NotificationsGateway,
     private emailService: EmailService,
     private smsService: SmsService,
+    private userPreferencesService: UserPreferencesService,
   ) {}
 
   async handleTransactionUpdate(transactionId: string) {
@@ -39,7 +41,10 @@ export class NotificationsService {
       const message = `Your transaction for property "${transaction.property.title}" has been updated to ${transaction.status}.`;
 
       // 1. In-App Notification
-      if (!preferences || preferences.inAppNotifications) {
+      const canInApp = await this.userPreferencesService.shouldDeliverNotification(
+        user.id, 'TRANSACTION_UPDATE', 'inApp',
+      );
+      if (canInApp) {
         await this.sendNotification(user.id, title, message, 'TRANSACTION_UPDATE', {
           transactionId: transaction.id,
           status: transaction.status,
@@ -47,7 +52,10 @@ export class NotificationsService {
       }
 
       // 2. Email Notification
-      if (preferences?.emailNotifications) {
+      const canEmail = await this.userPreferencesService.shouldDeliverNotification(
+        user.id, 'TRANSACTION_UPDATE', 'email',
+      );
+      if (canEmail) {
         await this.emailService.sendEmail({
           to: user.email,
           subject: `[PropChain] ${title}`,
@@ -58,7 +66,10 @@ export class NotificationsService {
       }
 
       // 3. SMS Notification
-      if (preferences?.smsNotifications && user.phone) {
+      const canSms = await this.userPreferencesService.shouldDeliverNotification(
+        user.id, 'TRANSACTION_UPDATE', 'sms',
+      );
+      if (canSms && user.phone) {
         await this.smsService.sendSms(user.phone, message);
       }
     }

--- a/src/users/dto/user-preferences.dto.ts
+++ b/src/users/dto/user-preferences.dto.ts
@@ -1,93 +1,230 @@
-import { IsBoolean, IsOptional, IsString, IsObject } from 'class-validator';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsObject,
+  IsIn,
+  IsArray,
+  ArrayUnique,
+  Matches,
+  ValidateIf,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export const NOTIFICATION_FREQUENCIES = ['INSTANT', 'HOURLY', 'DAILY', 'WEEKLY'] as const;
+export type NotificationFrequency = (typeof NOTIFICATION_FREQUENCIES)[number];
+
+export const NOTIFICATION_EVENT_TYPES = [
+  'TRANSACTION_UPDATE',
+  'PROPERTY_ALERT',
+  'MARKET_UPDATE',
+  'DISPUTE',
+  'SYSTEM',
+  'DOCUMENT',
+  'PAYMENT',
+] as const;
+export type NotificationEventType = (typeof NOTIFICATION_EVENT_TYPES)[number];
+
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 export class CreateUserPreferencesDto {
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   language?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   currency?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   timezone?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   emailNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   smsNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   pushNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   inAppNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   propertyAlerts?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   marketUpdates?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsObject()
-  perEventSettings?: any;
+  perEventSettings?: Record<string, any>;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   theme?: string;
 }
 
 export class UpdateUserPreferencesDto {
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   language?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   currency?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   timezone?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   emailNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   smsNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   pushNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   inAppNotifications?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   propertyAlerts?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsBoolean()
   marketUpdates?: boolean;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsObject()
-  perEventSettings?: any;
+  perEventSettings?: Record<string, any>;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   theme?: string;
+}
+
+// ─── Notification Preferences DTO (#370) ────────────────────────────────────
+
+export class UpdateNotificationPreferencesDto {
+  @ApiPropertyOptional({
+    description: 'Channel: enable/disable email notifications',
+  })
+  @IsOptional()
+  @IsBoolean()
+  emailNotifications?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Channel: enable/disable SMS notifications',
+  })
+  @IsOptional()
+  @IsBoolean()
+  smsNotifications?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Channel: enable/disable push notifications',
+  })
+  @IsOptional()
+  @IsBoolean()
+  pushNotifications?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Channel: enable/disable in-app notifications',
+  })
+  @IsOptional()
+  @IsBoolean()
+  inAppNotifications?: boolean;
+
+  @ApiPropertyOptional({
+    enum: NOTIFICATION_FREQUENCIES,
+    description: 'How often to batch and deliver notifications',
+  })
+  @IsOptional()
+  @IsIn(NOTIFICATION_FREQUENCIES)
+  notificationFrequency?: NotificationFrequency;
+
+  @ApiPropertyOptional({
+    isArray: true,
+    enum: NOTIFICATION_EVENT_TYPES,
+    description: 'Event types the user wants to receive. Empty array = all events.',
+  })
+  @IsOptional()
+  @IsArray()
+  @ArrayUnique()
+  @IsIn(NOTIFICATION_EVENT_TYPES, { each: true })
+  notificationEventTypes?: NotificationEventType[];
+
+  @ApiPropertyOptional({
+    description: 'Enable quiet hours (no notifications during the specified window)',
+  })
+  @IsOptional()
+  @IsBoolean()
+  quietHoursEnabled?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Quiet hours start time in HH:MM format (user local timezone)',
+    example: '22:00',
+  })
+  @ValidateIf((o) => o.quietHoursEnabled === true || o.quietHoursStart !== undefined)
+  @IsOptional()
+  @Matches(TIME_REGEX, { message: 'quietHoursStart must be in HH:MM format' })
+  quietHoursStart?: string;
+
+  @ApiPropertyOptional({
+    description: 'Quiet hours end time in HH:MM format (user local timezone)',
+    example: '08:00',
+  })
+  @ValidateIf((o) => o.quietHoursEnabled === true || o.quietHoursEnd !== undefined)
+  @IsOptional()
+  @Matches(TIME_REGEX, { message: 'quietHoursEnd must be in HH:MM format' })
+  quietHoursEnd?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Per-event channel overrides. Key = event type, value = { email, sms, push, inApp }',
+    example: {
+      TRANSACTION_UPDATE: { email: true, sms: true, push: false, inApp: true },
+      MARKET_UPDATE: { email: false, sms: false, push: false, inApp: true },
+    },
+  })
+  @IsOptional()
+  @IsObject()
+  perEventSettings?: Record<string, { email?: boolean; sms?: boolean; push?: boolean; inApp?: boolean }>;
 }

--- a/src/users/user-preferences.controller.ts
+++ b/src/users/user-preferences.controller.ts
@@ -1,31 +1,88 @@
-import { Controller, Get, Post, Body, Param, Put, Delete, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Body, Put, Delete, Patch, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { UserPreferencesService } from './user-preferences.service';
-import { CreateUserPreferencesDto, UpdateUserPreferencesDto } from './dto/user-preferences.dto';
+import {
+  CreateUserPreferencesDto,
+  UpdateUserPreferencesDto,
+  UpdateNotificationPreferencesDto,
+} from './dto/user-preferences.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 
+@ApiTags('User Preferences')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('users/preferences')
 export class UserPreferencesController {
   constructor(private readonly preferencesService: UserPreferencesService) {}
 
   @Get()
+  @ApiOperation({ summary: 'Get all preferences for the current user' })
+  @ApiResponse({ status: 200, description: 'Preferences returned successfully' })
   getPreferences(@CurrentUser() user: any) {
     return this.preferencesService.findByUserId(user.id);
   }
 
   @Post()
+  @ApiOperation({ summary: 'Create preferences for the current user' })
+  @ApiResponse({ status: 201, description: 'Preferences created successfully' })
   createPreferences(@CurrentUser() user: any, @Body() createDto: CreateUserPreferencesDto) {
     return this.preferencesService.create(user.id, createDto);
   }
 
   @Put()
+  @ApiOperation({ summary: 'Update all preferences for the current user' })
+  @ApiResponse({ status: 200, description: 'Preferences updated successfully' })
   updatePreferences(@CurrentUser() user: any, @Body() updateDto: UpdateUserPreferencesDto) {
     return this.preferencesService.update(user.id, updateDto);
   }
 
   @Delete()
+  @ApiOperation({ summary: 'Delete preferences for the current user' })
+  @ApiResponse({ status: 200, description: 'Preferences deleted successfully' })
   removePreferences(@CurrentUser() user: any) {
     return this.preferencesService.remove(user.id);
+  }
+
+  // ─── Notification Preferences (#370) ──────────────────────────────────────
+
+  @Get('notifications')
+  @ApiOperation({
+    summary: 'Get notification preferences',
+    description:
+      'Returns channel selection, delivery frequency, subscribed event types, and quiet hours settings.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Notification preferences returned successfully',
+    schema: {
+      example: {
+        channels: { email: true, sms: false, push: false, inApp: true },
+        frequency: 'INSTANT',
+        eventTypes: ['TRANSACTION_UPDATE', 'PROPERTY_ALERT'],
+        quietHours: { enabled: true, start: '22:00', end: '08:00' },
+        perEventSettings: {
+          MARKET_UPDATE: { email: false, sms: false, push: false, inApp: true },
+        },
+      },
+    },
+  })
+  getNotificationPreferences(@CurrentUser() user: any) {
+    return this.preferencesService.getNotificationPreferences(user.id);
+  }
+
+  @Patch('notifications')
+  @ApiOperation({
+    summary: 'Update notification preferences',
+    description:
+      'Update any combination of: channel selection (email/sms/push/inApp), delivery frequency (INSTANT/HOURLY/DAILY/WEEKLY), subscribed event types, quiet hours window, and per-event channel overrides.',
+  })
+  @ApiResponse({ status: 200, description: 'Notification preferences updated successfully' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
+  updateNotificationPreferences(
+    @CurrentUser() user: any,
+    @Body() dto: UpdateNotificationPreferencesDto,
+  ) {
+    return this.preferencesService.updateNotificationPreferences(user.id, dto);
   }
 }

--- a/src/users/user-preferences.service.ts
+++ b/src/users/user-preferences.service.ts
@@ -1,13 +1,16 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../database/prisma.service';
-import { CreateUserPreferencesDto, UpdateUserPreferencesDto } from './dto/user-preferences.dto';
+import {
+  CreateUserPreferencesDto,
+  UpdateUserPreferencesDto,
+  UpdateNotificationPreferencesDto,
+} from './dto/user-preferences.dto';
 
 @Injectable()
 export class UserPreferencesService {
   constructor(private prisma: PrismaService) {}
 
   async create(userId: string, data: CreateUserPreferencesDto) {
-    // Check if preferences already exist
     const existing = await this.prisma.userPreferences.findUnique({
       where: { userId },
     });
@@ -30,7 +33,6 @@ export class UserPreferencesService {
     });
 
     if (!preferences) {
-      // Create default preferences if not exist
       return this.create(userId, {});
     }
 
@@ -49,4 +51,158 @@ export class UserPreferencesService {
       where: { userId },
     });
   }
+
+  // ─── Notification Preferences (#370) ──────────────────────────────────────
+
+  /**
+   * Returns only the notification-related preference fields for the user.
+   */
+  async getNotificationPreferences(userId: string) {
+    const prefs = await this.findByUserId(userId);
+
+    return {
+      channels: {
+        email: prefs.emailNotifications,
+        sms: prefs.smsNotifications,
+        push: prefs.pushNotifications,
+        inApp: prefs.inAppNotifications,
+      },
+      frequency: prefs.notificationFrequency,
+      eventTypes: prefs.notificationEventTypes,
+      quietHours: {
+        enabled: prefs.quietHoursEnabled,
+        start: prefs.quietHoursStart ?? null,
+        end: prefs.quietHoursEnd ?? null,
+      },
+      perEventSettings: prefs.perEventSettings ?? {},
+    };
+  }
+
+  /**
+   * Updates only the notification-related preference fields.
+   */
+  async updateNotificationPreferences(
+    userId: string,
+    dto: UpdateNotificationPreferencesDto,
+  ) {
+    // Ensure preferences row exists
+    await this.findByUserId(userId);
+
+    const {
+      emailNotifications,
+      smsNotifications,
+      pushNotifications,
+      inAppNotifications,
+      notificationFrequency,
+      notificationEventTypes,
+      quietHoursEnabled,
+      quietHoursStart,
+      quietHoursEnd,
+      perEventSettings,
+    } = dto;
+
+    const updated = await this.prisma.userPreferences.update({
+      where: { userId },
+      data: {
+        ...(emailNotifications !== undefined && { emailNotifications }),
+        ...(smsNotifications !== undefined && { smsNotifications }),
+        ...(pushNotifications !== undefined && { pushNotifications }),
+        ...(inAppNotifications !== undefined && { inAppNotifications }),
+        ...(notificationFrequency !== undefined && { notificationFrequency }),
+        ...(notificationEventTypes !== undefined && { notificationEventTypes }),
+        ...(quietHoursEnabled !== undefined && { quietHoursEnabled }),
+        ...(quietHoursStart !== undefined && { quietHoursStart }),
+        ...(quietHoursEnd !== undefined && { quietHoursEnd }),
+        ...(perEventSettings !== undefined && { perEventSettings }),
+      },
+    });
+
+    return {
+      channels: {
+        email: updated.emailNotifications,
+        sms: updated.smsNotifications,
+        push: updated.pushNotifications,
+        inApp: updated.inAppNotifications,
+      },
+      frequency: updated.notificationFrequency,
+      eventTypes: updated.notificationEventTypes,
+      quietHours: {
+        enabled: updated.quietHoursEnabled,
+        start: updated.quietHoursStart ?? null,
+        end: updated.quietHoursEnd ?? null,
+      },
+      perEventSettings: updated.perEventSettings ?? {},
+    };
+  }
+
+  /**
+   * Checks whether a notification should be delivered to a user right now,
+   * respecting quiet hours and event-type subscriptions.
+   */
+  async shouldDeliverNotification(
+    userId: string,
+    eventType: string,
+    channel: 'email' | 'sms' | 'push' | 'inApp',
+  ): Promise<boolean> {
+    const prefs = await this.findByUserId(userId);
+
+    // Check if the channel is enabled globally
+    const channelMap: Record<string, boolean> = {
+      email: prefs.emailNotifications,
+      sms: prefs.smsNotifications,
+      push: prefs.pushNotifications,
+      inApp: prefs.inAppNotifications,
+    };
+    if (!channelMap[channel]) return false;
+
+    // Check per-event channel override
+    const perEvent = (prefs.perEventSettings as Record<string, any> | null) ?? {};
+    if (perEvent[eventType] && perEvent[eventType][channel] === false) return false;
+
+    // Check event type subscription (empty array = all events allowed)
+    const subscribedTypes: string[] = prefs.notificationEventTypes ?? [];
+    if (subscribedTypes.length > 0 && !subscribedTypes.includes(eventType)) return false;
+
+    // Check quiet hours
+    if (prefs.quietHoursEnabled && prefs.quietHoursStart && prefs.quietHoursEnd) {
+      const tz = prefs.timezone ?? 'UTC';
+      const now = new Date();
+      const formatter = new Intl.DateTimeFormat('en-GB', {
+        timeZone: tz,
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
+      const currentTime = formatter.format(now); // "HH:MM"
+
+      if (isInQuietWindow(currentTime, prefs.quietHoursStart, prefs.quietHoursEnd)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeToMinutes(t: string): number {
+  const [h, m] = t.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/**
+ * Returns true if `current` falls within [start, end) window,
+ * handling overnight ranges (e.g. 22:00 – 08:00).
+ */
+function isInQuietWindow(current: string, start: string, end: string): boolean {
+  const c = timeToMinutes(current);
+  const s = timeToMinutes(start);
+  const e = timeToMinutes(end);
+
+  if (s <= e) {
+    return c >= s && c < e;
+  }
+  // Overnight window
+  return c >= s || c < e;
 }


### PR DESCRIPTION
Adds user notification preference settings with full channel selection (email, SMS, push, in-app), delivery frequency (INSTANT/HOURLY/DAILY/WEEKLY), event type subscriptions, quiet hours with overnight window support, and per-event channel overrides. Includes Prisma schema update, migration, and new GET/PATCH /users/preferences/notifications endpoints. NotificationsService now respects all preference rules before delivering.

Closes #370