### PR TITLE
Search + Cache Reliability Increment: Tagged Property Invalidation, Cache Health Checks, and View Leaderboard Endpoint

### DIFF
--- a/src/cache/cache-stats.controller.ts
+++ b/src/cache/cache-stats.controller.ts
@@ -20,6 +20,18 @@ export class CacheStatsController {
     return this.monitoring.getMetrics();
   }
 
+  @Get('health')
+  async health() {
+    const connected = await this.cacheService.isConnected();
+    const stats = await this.cacheService.getStats();
+    return {
+      status: connected ? 'ok' : 'degraded',
+      connected,
+      metrics: this.monitoring.getMetrics(),
+      cache: stats,
+    };
+  }
+
   @Delete('clear')
   async clearCache() {
     await this.cacheService.clear();

--- a/src/properties/properties.module.ts
+++ b/src/properties/properties.module.ts
@@ -11,9 +11,10 @@ import { PropertiesResolver } from './properties.resolver';
 import { PubSub } from 'graphql-subscriptions';
 import { FraudModule } from '../fraud/fraud.module';
 import { PropertyReportService } from './report/property-report.service';
+import { CacheModuleConfig } from '../cache/cache.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, FraudModule, ConfigModule],
+  imports: [PrismaModule, AuthModule, FraudModule, ConfigModule, CacheModuleConfig],
   controllers: [PropertiesController, PropertyImagesController],
   providers: [
     PropertiesService,

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -14,6 +14,8 @@ import { CreateAmenityDto, UpdateAmenityDto } from './dto/amenity.dto';
 import { FraudService } from '../fraud/fraud.service';
 import { GeocodingService } from './geocoding.service';
 import { PropertyStatus, UserRole } from '../types/prisma.types';
+import { CacheService } from '../cache/cache.service';
+import { CACHE_TAGS } from '../cache/cache.config';
 import {
   canTransitionPropertyStatus,
   getAllowedNextPropertyStatuses,
@@ -41,6 +43,7 @@ export class PropertiesService {
     private readonly prisma: PrismaService,
     private readonly fraudService: FraudService,
     private readonly geocodingService: GeocodingService,
+    private readonly cacheService: CacheService,
   ) {}
 
   async create(createPropertyDto: CreatePropertyDto, ownerId: string) {
@@ -95,6 +98,7 @@ export class PropertiesService {
     });
 
     await this.fraudService.evaluatePropertyCreated(property.id);
+    await this.cacheService.invalidateByTag(CACHE_TAGS.PROPERTIES);
 
     return property;
   }
@@ -236,7 +240,7 @@ export class PropertiesService {
       }
     }
 
-    return this.prisma.property.update({
+    const updated = await this.prisma.property.update({
       where: { id },
       data: {
         ...rest,
@@ -249,12 +253,16 @@ export class PropertiesService {
         longitude: resolvedLng,
       },
     });
+    await this.cacheService.invalidateByTag(CACHE_TAGS.PROPERTIES);
+    return updated;
   }
 
   async remove(id: string) {
-    return this.prisma.property.delete({
+    const deleted = await this.prisma.property.delete({
       where: { id },
     });
+    await this.cacheService.invalidateByTag(CACHE_TAGS.PROPERTIES);
+    return deleted;
   }
 
   async findByOwnerId(ownerId: string) {

--- a/src/property-views/property-views.controller.ts
+++ b/src/property-views/property-views.controller.ts
@@ -104,6 +104,14 @@ export class PropertyViewsController {
     });
   }
 
+  @Get('leaderboard')
+  leaderboard(@Query() query: PopularPropertiesQueryDto) {
+    return this.propertyViewsService.getPopularProperties({
+      take: query.take,
+      since: this.parseSince(query.since),
+    });
+  }
+
   private parseSince(since?: string): Date | undefined {
     if (!since) return undefined;
     const date = new Date(since);

--- a/src/search/search.controller.ts
+++ b/src/search/search.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Query, Body, UseGuards, Request } from '@nestjs/common';
 import { SearchService, SearchQuery } from './search.service';
+import { SearchAutocompleteService } from './search-autocomplete.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
 
@@ -15,7 +16,10 @@ interface AuthenticatedRequest extends Request {
 @Controller('search')
 @UseGuards(JwtAuthGuard)
 export class SearchController {
-  constructor(private readonly searchService: SearchService) {}
+  constructor(
+    private readonly searchService: SearchService,
+    private readonly searchAutocompleteService: SearchAutocompleteService,
+  ) {}
 
   @Post('properties')
   @ApiOperation({ summary: 'Search properties with advanced filters' })
@@ -30,6 +34,15 @@ export class SearchController {
   @ApiResponse({ status: 200, description: 'Suggestions returned successfully' })
   async getSuggestions(@Query('q') query?: string) {
     return this.searchService.getSuggestions(query || '');
+  }
+
+  @Get('autocomplete')
+  @ApiOperation({ summary: 'Get live autocomplete suggestions for partial input' })
+  @ApiQuery({ name: 'q', required: true, description: 'Partial search query' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Max number of suggestions' })
+  async autocomplete(@Query('q') query: string, @Query('limit') limit?: string) {
+    const parsedLimit = limit ? Math.max(1, Math.min(20, Number(limit))) : 10;
+    return this.searchAutocompleteService.getSuggestions(query || '', parsedLimit);
   }
 
   @Get('filters/saved')


### PR DESCRIPTION
## Summary
Minimal API/performance slice for assigned issues.

### Included
- Added tag-based property cache invalidation on property create/update/delete.
- Added `GET /cache/health` endpoint exposing connectivity + cache metrics snapshot.
- Added `GET /search/autocomplete` endpoint for partial text suggestions with result limit bounds.
- Added `GET /property-views/leaderboard` alias backed by existing most-viewed query.

## Notes
- Existing view counting and popular-property analytics were already present; this PR exposes the leaderboard endpoint shape required by the issue batch.

Closes #578
Closes #579
Closes #580
Closes #581
