### PR TITLE
Feat/test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to PropChain BackEnd
+
+Thank you for helping improve PropChain! This guide explains how to contribute issues and pull requests, what we expect from branches and PRs, and how to run tests and lint locally.
+
+## 1. Report an Issue
+
+If you find a bug or want to request a feature:
+
+1. Search existing issues first to avoid duplicates.
+2. Open a new issue with:
+   - Clear title
+   - Description of the problem or enhancement
+   - Steps to reproduce (for bugs)
+   - Expected vs actual behavior
+   - Relevant environment, logs, or screenshots
+
+## 2. Start a Branch
+
+Create branches from `main` and use a descriptive, consistent branch name:
+
+- `feature/<ticket-number>-<short-description>`
+- `bugfix/<ticket-number>-<short-description>`
+- `fix/<ticket-number>-<short-description>`
+- `chore/<short-description>`
+
+Examples:
+
+- `feature/123-add-login-rate-limiting`
+- `bugfix/456-fix-dispute-controller-roles`
+- `chore/update-prisma-schema`
+
+Branch names should be lowercase, use hyphens, and briefly describe the change.
+
+## 3. Work on Your Change
+
+Use the existing repo scripts and conventions:
+
+- Install dependencies: `npm install`
+- Start development mode: `npm run start:dev`
+- Generate Prisma client: `npm run db:generate`
+- Run migrations locally: `npm run migrate`
+- Reset migrations when needed: `npm run migrate:reset`
+
+Keep each PR focused on a single issue or feature whenever possible.
+
+## 4. Run Tests and Lint Locally
+
+Before opening a PR, run the relevant checks:
+
+- Run all tests: `npm test`
+- Run tests in watch mode: `npm run test:watch`
+- Run test coverage: `npm run test:cov`
+- Run lint and apply automatic fixes: `npm run lint`
+- Format code: `npm run format`
+
+If your change touches database schema or Prisma models, update the schema and run:
+
+```bash
+npm run db:generate
+npm run migrate
+```
+
+## 5. Pull Request Expectations
+
+When you open a PR, please include:
+
+- A descriptive title
+- A short summary of the change
+- Related issue number(s)
+- Testing steps and commands run locally
+- Any setup notes such as environment variables or migrations
+- Screenshots or API request examples when relevant
+
+A good PR should be:
+
+- Small and focused
+- Based on an up-to-date `main`
+- Passing tests and lint checks
+- Clear about the problem and the solution
+
+## 6. Review and Feedback
+
+- Link the PR to the related issue when available.
+- Keep discussion in the PR thread.
+- Address feedback promptly by updating the branch.
+- Rebase or merge `main` if needed to resolve conflicts.
+
+## 7. Code Style and Standards
+
+This repository uses ESLint and Prettier.
+
+- Follow existing code patterns and module boundaries.
+- Keep naming clear and consistent.
+- Prefer small, testable changes.
+- Avoid commented-out code in production commits.
+
+## 8. Additional Notes
+
+- If your change involves database migrations, include migration details in the PR.
+- If you add or update docs, link them from the PR description.
+- Make sure environment variables are not committed.
+
+Thank you for contributing to PropChain!

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ npm run test:cov
 npm run test:watch
 ```
 
+For database-backed integration tests, set `TEST_DATABASE_URL` to a dedicated test database. Helper utilities are available in `test/database/prisma-test-helpers.ts` to clean fixtures and reset seeded state between suites.
+
 ## 📁 Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ Tax strategy suggestions are informational only and are not legal or tax advice.
 
 ## 🤝 Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines, branch naming conventions, PR expectations, and local test/lint instructions.
+
+
 1. Fork the repository
 2. Create your feature branch (`git checkout -b feature/amazing-feature`)
 3. Commit your changes (`git commit -m 'Add amazing feature'`)

--- a/test/api/api.spec.ts
+++ b/test/api/api.spec.ts
@@ -53,10 +53,10 @@ describe('AnalyticsInterceptor (integration test)', () => {
   });
 });
 
-describe('Performance tests', () => {
-  it('AnalyticsService handles 1000 records within 50ms', () => {
+describe('Analytics behavior', () => {
+  it('collects metrics for repeated requests', () => {
     const service = new AnalyticsService();
-    const start = Date.now();
+
     for (let i = 0; i < 1000; i++) {
       service.record({
         endpoint: `/api/route${i % 10}`,
@@ -65,18 +65,25 @@ describe('Performance tests', () => {
         responseTime: i,
       });
     }
-    service.getStats();
-    expect(Date.now() - start).toBeLessThan(50);
-  });
 
-  it('CacheMonitoringService handles 1000 hits within 10ms', () => {
-    const monitoring = new CacheMonitoringService();
-    const start = Date.now();
-    for (let i = 0; i < 1000; i++) monitoring.recordHit();
-    expect(Date.now() - start).toBeLessThan(10);
-    expect(monitoring.getMetrics().hits).toBe(1000);
+    const stats = service.getStats();
+    expect(stats.total).toBe(1000);
+    expect(stats.endpoints.length).toBeGreaterThan(0);
+    expect(stats.endpoints.some((item) => item.endpoint === 'GET /api/route0')).toBe(true);
   });
 });
 
-// Import needed for performance test
 import { CacheMonitoringService } from '../../src/cache/cache-monitoring.service';
+
+describe('CacheMonitoringService', () => {
+  it('tracks hits correctly', async () => {
+    const monitoring = new CacheMonitoringService();
+
+    for (let i = 0; i < 1000; i++) {
+      await monitoring.recordHit();
+    }
+
+    expect(monitoring.getMetrics().hits).toBe(1000);
+    expect(monitoring.getMetrics().misses).toBe(0);
+  });
+});

--- a/test/database/prisma-test-helpers.spec.ts
+++ b/test/database/prisma-test-helpers.spec.ts
@@ -1,0 +1,65 @@
+import { PrismaClient, Prisma } from '@prisma/client';
+import { cleanupDatabase, createTestPrismaClient, resetTestDatabase } from './prisma-test-helpers';
+
+const databaseUrl = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+
+const describeIfDatabase = databaseUrl ? describe : describe.skip;
+
+describeIfDatabase('Prisma test helpers', () => {
+  let prisma: PrismaClient;
+
+  beforeAll(async () => {
+    prisma = createTestPrismaClient();
+    await prisma.$connect();
+  });
+
+  afterAll(async () => {
+    await cleanupDatabase(prisma);
+    await prisma.$disconnect();
+  });
+
+  beforeEach(async () => {
+    await resetTestDatabase(prisma, async (db) => {
+      await db.user.create({
+        data: {
+          email: 'test-seed@example.com',
+          firstName: 'Seed',
+          lastName: 'User',
+        },
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await cleanupDatabase(prisma);
+  });
+
+  it('cleans created records after each test', async () => {
+    const seedUser = await prisma.user.findUnique({ where: { email: 'test-seed@example.com' } });
+    expect(seedUser).toBeTruthy();
+
+    const property = await prisma.property.create({
+      data: {
+        title: 'Test Property',
+        address: '123 Test Lane',
+        city: 'Testville',
+        state: 'TS',
+        zipCode: '12345',
+        price: new Prisma.Decimal(100000),
+        propertyType: 'House',
+        features: [],
+        tags: [],
+        ownerId: seedUser!.id,
+      },
+    });
+
+    expect(property).toBeDefined();
+    expect(await prisma.property.count()).toBe(1);
+  });
+
+  it('resets seeded data between test suites', async () => {
+    const seedUser = await prisma.user.findUnique({ where: { email: 'test-seed@example.com' } });
+    expect(seedUser).toBeTruthy();
+    expect(seedUser?.firstName).toBe('Seed');
+  });
+});

--- a/test/database/prisma-test-helpers.ts
+++ b/test/database/prisma-test-helpers.ts
@@ -1,0 +1,96 @@
+import { PrismaClient } from '@prisma/client';
+
+const TEST_TABLES = [
+  'users',
+  'database_backups',
+  'backup_schedule_configs',
+  'api_keys',
+  'password_history',
+  'blacklisted_tokens',
+  'password_reset_tokens',
+  'login_attempts',
+  'login_history',
+  'properties',
+  'property_images',
+  'property_favorites',
+  'property_views',
+  'neighborhoods',
+  'neighborhood_schools',
+  'neighborhood_amenities',
+  'transactions',
+  'transaction_tax_strategies',
+  'documents',
+  'document_versions',
+  'user_preferences',
+  'activity_logs',
+  'sessions',
+  'fraud_alerts',
+  'fraud_investigation_notes',
+  'verification_documents',
+  'saved_filters',
+  'search_analytics',
+  'search_history',
+  'popular_searches',
+  'search_suggestions',
+  'notifications',
+  'disputes',
+  'transaction_milestones',
+  'transaction_history',
+  'link_clicks',
+  'email_engagements',
+  'email_bounces',
+  'digest_preferences',
+  'property_agents',
+  'commissions',
+  'property_amenities',
+  'property_duplicates',
+  'transaction_notes',
+  'open_houses',
+  'open_house_rsvps',
+];
+
+const TRUNCATE_SQL = `TRUNCATE TABLE ${TEST_TABLES.map((table) => `"${table}"`).join(', ')} RESTART IDENTITY CASCADE;`;
+
+export function createTestPrismaClient(): PrismaClient {
+  const databaseUrl = process.env.TEST_DATABASE_URL || process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error(
+      'Missing test database URL. Set TEST_DATABASE_URL or DATABASE_URL before running database-backed tests.',
+    );
+  }
+
+  return new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
+}
+
+export async function cleanupDatabase(prisma: PrismaClient): Promise<void> {
+  await prisma.$executeRawUnsafe(TRUNCATE_SQL);
+}
+
+export async function resetTestDatabase(
+  prisma: PrismaClient,
+  seedFn?: (prisma: PrismaClient) => Promise<void>,
+): Promise<void> {
+  await cleanupDatabase(prisma);
+  if (seedFn) {
+    await seedFn(prisma);
+  }
+}
+
+export async function withDatabaseCleanup<T>(fn: (prisma: PrismaClient) => Promise<T>): Promise<T> {
+  const prisma = createTestPrismaClient();
+  await prisma.$connect();
+
+  try {
+    return await fn(prisma);
+  } finally {
+    await cleanupDatabase(prisma);
+    await prisma.$disconnect();
+  }
+}


### PR DESCRIPTION
## Done

### What changed

- Added prisma-test-helpers.ts
  - `createTestPrismaClient()`
  - `cleanupDatabase(prisma)`
  - `resetTestDatabase(prisma, seedFn?)`
  - `withDatabaseCleanup(fn)`

- Added prisma-test-helpers.spec.ts
  - demonstrates seeded data reset between tests
  - verifies created records are cleaned after each test
  - uses `TEST_DATABASE_URL` / `DATABASE_URL` for database-backed test execution

- Stabilized a flaky test in api.spec.ts
  - removed strict timing assertions
  - now verifies correct analytics and cache hit behavior instead of wall-clock performance

- Updated README.md
  - added note about `TEST_DATABASE_URL`
  - referenced the new DB fixture helpers

### Why this meets acceptance

- Created records are cleaned after tests via `cleanupDatabase`
- Seeded fixture state is reset between suites through `resetTestDatabase`
- Helper utilities now directly support cleanup and reset
- Flaky time-sensitive tests were audited and refactored for stability

Made changes.

Closes #613
closes #615 