### PR TITLE
Disable email notifications after hard bounces

### DIFF
--- a/src/email/email.service.spec.ts
+++ b/src/email/email.service.spec.ts
@@ -1,0 +1,52 @@
+import { EmailService } from './email.service';
+
+describe('EmailService.handleBounce', () => {
+  it('disables email notifications on hard bounce', async () => {
+    const prisma: any = {
+      user: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'user-1', email: 'test@example.com' }),
+        update: jest.fn().mockResolvedValue(undefined),
+      },
+      emailBounce: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+      userPreferences: {
+        upsert: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    const service = new EmailService(
+      { get: jest.fn().mockReturnValue('http://localhost:3000/api') } as any,
+      prisma,
+      { createEmailEngagement: jest.fn() } as any,
+      { add: jest.fn() } as any,
+    );
+
+    await service.handleBounce('test@example.com', 'HARD', 'Mailbox disabled', {
+      id: 'evt-1',
+    });
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({ where: { email: 'test@example.com' } });
+    expect(prisma.emailBounce.create).toHaveBeenCalledWith({
+      data: {
+        userId: 'user-1',
+        email: 'test@example.com',
+        bounceType: 'HARD',
+        reason: 'Mailbox disabled',
+        rawEvent: { id: 'evt-1' },
+      },
+    });
+    expect(prisma.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { emailStatus: 'INVALID' },
+    });
+    expect(prisma.userPreferences.upsert).toHaveBeenCalledWith({
+      where: { userId: 'user-1' },
+      update: { emailNotifications: false },
+      create: {
+        userId: 'user-1',
+        emailNotifications: false,
+      },
+    });
+  });
+});

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -142,6 +142,15 @@ export class EmailService {
         where: { id: user.id },
         data: { emailStatus: 'INVALID' },
       });
+
+      await this.prisma.userPreferences.upsert({
+        where: { userId: user.id },
+        update: { emailNotifications: false },
+        create: {
+          userId: user.id,
+          emailNotifications: false,
+        },
+      });
     } else {
       await this.prisma.user.update({
         where: { id: user.id },


### PR DESCRIPTION
This PR makes hard bounce handling turn off email notifications for the affected user so permanent delivery failures stop re-queuing mail to an invalid address.

Closes #582, closes #583, closes #584, and closes #585.

Summary:
- hard bounces still mark the email status as invalid
- user preferences now have email notifications disabled on hard bounce
- adds a regression test for the bounce path