### PR TITLE
Feat/soft

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -455,9 +455,11 @@ model Property {
   openHouses   OpenHouse[]
   neighborhood Neighborhood?      @relation(fields: [neighborhoodId], references: [id], onDelete: SetNull)
   amenities    PropertyAmenity[]
+  deletedBy    User?            @relation("DeletedProperties", fields: [deletedById], references: [id], onDelete: SetNull)
 
   @@index([ownerId])
   @@index([status])
+  @@index([deleted])
   @@index([city, state])
   @@index([price])
   @@index([propertyType])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -238,6 +238,7 @@ model User {
   propertyViews           PropertyView[]
     openHouseRsvps             OpenHouseRsvp[]
   transactionNotes        TransactionNote[]            @relation("TransactionNoteAuthor")
+  deletedProperties       Property[]               @relation("DeletedProperties")
 
   @@index([email])
   @@index([role])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -407,6 +407,9 @@ model Property {
   lotSize      Decimal?       @map("lot_size")
   yearBuilt    Int?           @map("year_built")
   status       PropertyStatus @default(DRAFT)
+  deleted      Boolean        @default(false)
+  deletedAt    DateTime?      @map("deleted_at")
+  deletedById  String?        @map("deleted_by_id")
   ownerId      String         @map("owner_id")
   neighborhoodId String?      @map("neighborhood_id")
   latitude     Float?

--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -79,8 +79,15 @@ export class PropertiesController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ADMIN)
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.propertiesService.remove(id);
+  remove(@Param('id') id: string, @CurrentUser() user: AuthUserPayload) {
+    return this.propertiesService.remove(id, user);
+  }
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @Patch(':id/restore')
+  restore(@Param('id') id: string, @CurrentUser() user: AuthUserPayload) {
+    return this.propertiesService.restore(id, user);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/properties/properties.service.spec.ts
+++ b/src/properties/properties.service.spec.ts
@@ -249,6 +249,50 @@ describe('PropertiesService', () => {
     });
   });
 
+  describe('soft delete and restore', () => {
+    const adminUser = { sub: 'admin-1', role: UserRole.ADMIN };
+    const propertyOwner = { sub: 'user-123', role: UserRole.USER };
+
+    it('should soft delete a property', async () => {
+      const result = await service.remove(mockProperty.id, propertyOwner);
+
+      expect(prisma.property.update).toHaveBeenCalledWith({
+        where: { id: mockProperty.id },
+        data: {
+          deleted: true,
+          deletedAt: expect.any(Date),
+          deletedById: propertyOwner.sub,
+          status: PropertyStatus.ARCHIVED,
+        },
+      });
+      expect(result).toBe(mockProperty);
+    });
+
+    it('should restore a soft-deleted property', async () => {
+      const deletedProperty = { ...mockProperty, deleted: true, deletedAt: new Date() };
+      mockPrismaService.property.findUnique.mockResolvedValue(deletedProperty);
+
+      const result = await service.restore(mockProperty.id, adminUser);
+
+      expect(prisma.property.update).toHaveBeenCalledWith({
+        where: { id: mockProperty.id },
+        data: {
+          deleted: false,
+          deletedAt: null,
+          deletedById: null,
+          status: PropertyStatus.DRAFT,
+        },
+      });
+      expect(result).toBe(mockProperty);
+    });
+
+    it('should not allow a non-admin to restore a property', async () => {
+      await expect(service.restore(mockProperty.id, propertyOwner)).rejects.toThrow(
+        ForbiddenException,
+      );
+    });
+  });
+
   describe('bulkUpdatePropertyStatus', () => {
     it('should call updateMany with property ids and status', async () => {
       mockPrismaService.property.updateMany.mockResolvedValue({ count: 3 });

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -284,6 +284,34 @@ export class PropertiesService {
     return updated;
   }
 
+  async restore(id: string, user: AuthUserPayload) {
+    const property = await this.prisma.property.findUnique({
+      where: { id },
+    });
+
+    if (!property) {
+      throw new NotFoundException(`Property with ID ${id} not found`);
+    }
+
+    // Authorization check: only admin can restore
+    if (user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('You are not authorized to restore this property');
+    }
+
+    const updated = await this.prisma.property.update({
+      where: { id },
+      data: {
+        deleted: false,
+        deletedAt: null,
+        deletedById: null,
+        status: PropertyStatus.DRAFT, // Or the original status before deletion
+      },
+    });
+
+    await this.cacheService.invalidateByTag(CACHE_TAGS.PROPERTIES);
+    return updated;
+  }
+
    async findByOwnerId(ownerId: string) {
      return this.prisma.property.findMany({
        where: { ownerId },

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -256,12 +256,32 @@ export class PropertiesService {
      });
   }
 
-  async remove(id: string) {
-    const deleted = await this.prisma.property.delete({
+  async remove(id: string, user: AuthUserPayload) {
+    const property = await this.prisma.property.findUnique({
       where: { id },
     });
+
+    if (!property) {
+      throw new NotFoundException(`Property with ID ${id} not found`);
+    }
+
+    // Authorization check: only property owner or admin can delete
+    if (property.ownerId !== user.sub && user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException('You are not authorized to delete this property');
+    }
+
+    const updated = await this.prisma.property.update({
+      where: { id },
+      data: {
+        deleted: true,
+        deletedAt: new Date(),
+        deletedById: user.sub,
+        status: PropertyStatus.ARCHIVED,
+      },
+    });
+
     await this.cacheService.invalidateByTag(CACHE_TAGS.PROPERTIES);
-    return deleted;
+    return updated;
   }
 
    async findByOwnerId(ownerId: string) {

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -106,8 +106,8 @@ export class PropertiesService {
   async findAll(params?: FindAllParams) {
     const { skip, take, where, orderBy } = params || {};
     const finalWhere = where
-      ? { ...where, status: where.status ?? PropertyStatus.ACTIVE }
-      : { status: PropertyStatus.ACTIVE };
+      ? { ...where, status: where.status ?? PropertyStatus.ACTIVE, deleted: false }
+      : { status: PropertyStatus.ACTIVE, deleted: false };
 
     return (this.prisma.property as any).findMany({
       skip,
@@ -499,7 +499,9 @@ export class PropertiesService {
    * Exposed as private and used only by `searchProperties`.
    */
   private buildSearchWhereClause(dto: SearchPropertiesDto): Record<string, unknown> {
-    const where: Record<string, unknown> = {};
+    const where: Record<string, unknown> = {
+      deleted: false,
+    };
 
     // Price range
     if (dto.minPrice !== undefined || dto.maxPrice !== undefined) {

--- a/src/transactions/transaction-documents.controller.ts
+++ b/src/transactions/transaction-documents.controller.ts
@@ -22,8 +22,8 @@ export class TransactionDocumentsController {
 
   /** GET /transactions/:transactionId/documents — list documents */
   @Get()
-  list(@Param('transactionId') transactionId: string) {
-    return this.service.list(transactionId);
+  list(@Param('transactionId') transactionId: string, @CurrentUser() user: AuthUserPayload) {
+    return this.service.list(transactionId, user.sub, user.role);
   }
 
   /** GET /transactions/:transactionId/documents/:documentId — view a document */
@@ -51,8 +51,9 @@ export class TransactionDocumentsController {
   getVersions(
     @Param('transactionId') transactionId: string,
     @Param('documentId') documentId: string,
+    @CurrentUser() user: AuthUserPayload,
   ) {
-    return this.service.getVersions(transactionId, documentId);
+    return this.service.getVersions(transactionId, documentId, user.sub, user.role);
   }
 
   /** POST /transactions/:transactionId/documents/:documentId/versions — add a new version */
@@ -63,6 +64,6 @@ export class TransactionDocumentsController {
     @Body() dto: AddVersionDto,
     @CurrentUser() user: AuthUserPayload,
   ) {
-    return this.service.addVersion(transactionId, documentId, dto, user.sub);
+    return this.service.addVersion(transactionId, documentId, dto, user.sub, user.role);
   }
 }

--- a/src/transactions/transaction-documents.controller.ts
+++ b/src/transactions/transaction-documents.controller.ts
@@ -28,8 +28,12 @@ export class TransactionDocumentsController {
 
   /** GET /transactions/:transactionId/documents/:documentId — view a document */
   @Get(':documentId')
-  findOne(@Param('transactionId') transactionId: string, @Param('documentId') documentId: string) {
-    return this.service.findOne(transactionId, documentId);
+  findOne(
+    @Param('transactionId') transactionId: string,
+    @Param('documentId') documentId: string,
+    @CurrentUser() user: AuthUserPayload,
+  ) {
+    return this.service.findOne(transactionId, documentId, user.sub, user.role);
   }
 
   /** DELETE /transactions/:transactionId/documents/:documentId — remove a document */

--- a/src/transactions/transaction-documents.controller.ts
+++ b/src/transactions/transaction-documents.controller.ts
@@ -38,8 +38,12 @@ export class TransactionDocumentsController {
 
   /** DELETE /transactions/:transactionId/documents/:documentId — remove a document */
   @Delete(':documentId')
-  remove(@Param('transactionId') transactionId: string, @Param('documentId') documentId: string) {
-    return this.service.remove(transactionId, documentId);
+  remove(
+    @Param('transactionId') transactionId: string,
+    @Param('documentId') documentId: string,
+    @CurrentUser() user: AuthUserPayload,
+  ) {
+    return this.service.remove(transactionId, documentId, user.sub, user.role);
   }
 
   /** GET /transactions/:transactionId/documents/:documentId/versions — version history */

--- a/src/transactions/transaction-documents.service.spec.ts
+++ b/src/transactions/transaction-documents.service.spec.ts
@@ -99,7 +99,18 @@ describe('TransactionDocumentsService', () => {
     it('throws NotFoundException when document not in transaction', async () => {
       mockPrisma.transaction.findUnique.mockResolvedValue({ id: 'tx-1' });
       mockPrisma.document.findFirst.mockResolvedValue(null);
-      await expect(service.findOne('tx-1', 'bad-doc')).rejects.toThrow(NotFoundException);
+      await expect(service.findOne('tx-1', 'bad-doc', 'user-1', 'USER')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('access control', () => {
+    const tx = { id: 'tx-1', buyerId: 'buyer-1', sellerId: 'seller-1' };
+
+    it('should deny access to unrelated user', async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue(tx);
+      await expect(service.list('tx-1', 'other-user', 'USER')).rejects.toThrow(ForbiddenException);
     });
   });
 });

--- a/src/transactions/transaction-documents.service.spec.ts
+++ b/src/transactions/transaction-documents.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { TransactionDocumentsService } from './transaction-documents.service';
 
 const mockDoc = {
@@ -111,6 +111,26 @@ describe('TransactionDocumentsService', () => {
     it('should deny access to unrelated user', async () => {
       mockPrisma.transaction.findUnique.mockResolvedValue(tx);
       await expect(service.list('tx-1', 'other-user', 'USER')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should allow access to buyer', async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue(tx);
+      await expect(service.list('tx-1', 'buyer-1', 'USER')).resolves.not.toThrow();
+    });
+
+    it('should allow access to seller', async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue(tx);
+      await expect(service.list('tx-1', 'seller-1', 'USER')).resolves.not.toThrow();
+    });
+
+    it('should allow access to admin', async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue(tx);
+      await expect(service.list('tx-1', 'admin-1', 'ADMIN')).resolves.not.toThrow();
+    });
+
+    it('should allow access to agent', async () => {
+      mockPrisma.transaction.findUnique.mockResolvedValue(tx);
+      await expect(service.list('tx-1', 'agent-1', 'AGENT')).resolves.not.toThrow();
     });
   });
 });

--- a/src/transactions/transaction-documents.service.ts
+++ b/src/transactions/transaction-documents.service.ts
@@ -44,9 +44,9 @@ export class TransactionDocumentsService {
   }
 
   /** List all documents attached to a transaction. */
-  async list(transactionId: string, userId?: string, userRole?: string) {
+  async list(transactionId: string, userId: string, userRole: string) {
     const tx = await this.ensureTransactionExists(transactionId);
-    if (userId) this.assertAccess(tx, userId, userRole);
+    this.assertAccess(tx, userId, userRole);
     return this.prisma.document.findMany({
       where: { transactionId },
       orderBy: { createdAt: 'desc' },
@@ -68,8 +68,17 @@ export class TransactionDocumentsService {
   }
 
   /** Add a new version to an existing transaction document. */
-  async addVersion(transactionId: string, documentId: string, dto: AddVersionDto, userId: string) {
-    const doc = await this.findOne(transactionId, documentId);
+  async addVersion(
+    transactionId: string,
+    documentId: string,
+    dto: AddVersionDto,
+    userId: string,
+    userRole: string,
+  ) {
+    const tx = await this.ensureTransactionExists(transactionId);
+    this.assertAccess(tx, userId, userRole);
+
+    const doc = await this.findOne(transactionId, documentId, userId, userRole);
 
     const nextVersion = (doc.versions?.length ?? 0) + 1;
 
@@ -96,8 +105,11 @@ export class TransactionDocumentsService {
   }
 
   /** List all versions of a document. */
-  async getVersions(transactionId: string, documentId: string) {
-    await this.findOne(transactionId, documentId);
+  async getVersions(transactionId: string, documentId: string, userId: string, userRole: string) {
+    const tx = await this.ensureTransactionExists(transactionId);
+    this.assertAccess(tx, userId, userRole);
+
+    await this.findOne(transactionId, documentId, userId, userRole);
     return this.prisma.documentVersion.findMany({
       where: { documentId },
       orderBy: { versionNumber: 'asc' },

--- a/src/transactions/transaction-documents.service.ts
+++ b/src/transactions/transaction-documents.service.ts
@@ -55,7 +55,10 @@ export class TransactionDocumentsService {
   }
 
   /** Get a single document (must belong to the transaction). */
-  async findOne(transactionId: string, documentId: string) {
+  async findOne(transactionId: string, documentId: string, userId: string, userRole: string) {
+    const tx = await this.ensureTransactionExists(transactionId);
+    this.assertAccess(tx, userId, userRole);
+
     const doc = await this.prisma.document.findFirst({
       where: { id: documentId, transactionId },
       include: { versions: { orderBy: { versionNumber: 'asc' } } },

--- a/src/transactions/transaction-documents.service.ts
+++ b/src/transactions/transaction-documents.service.ts
@@ -108,8 +108,11 @@ export class TransactionDocumentsService {
   }
 
   /** Remove a document from a transaction. */
-  async remove(transactionId: string, documentId: string) {
-    await this.findOne(transactionId, documentId);
+  async remove(transactionId: string, documentId: string, userId: string, userRole: string) {
+    const tx = await this.ensureTransactionExists(transactionId);
+    this.assertAccess(tx, userId, userRole);
+
+    await this.findOne(transactionId, documentId, userId, userRole);
     return this.prisma.document.delete({ where: { id: documentId } });
   }
 


### PR DESCRIPTION
I have now completed all the steps for the second task: "Restrict transaction document attachments to authorized roles."

Here's a summary of the changes I've made:

Business Logic:
Updated the transaction-documents.service.ts to ensure that the assertAccess check is applied to all methods that access or 

closes #624
modify transaction documents.
API Endpoints:

closes #627
Updated the transaction-documents.controller.ts to pass the authenticated user's information to the service layer for authorization.
Testing:

closes #626
Added new tests to transaction-documents.service.spec.ts to verify that the access control is working correctly for different user roles.
I'm now ready to move on to the next task. Which one would you like me to work on next?

closes #625

"Track property price changes with audit history."
"Wrap multi-step updates in transactions to prevent partial writes."