### PR TITLE
fix: add @Type(() => Date) and @IsISO8601 to audit log query DTO

### DIFF
--- a/src/transactions/dto/audit-log-query.dto.ts
+++ b/src/transactions/dto/audit-log-query.dto.ts
@@ -1,0 +1,31 @@
+﻿import { Type } from 'class-transformer';
+import { IsISO8601, IsOptional, IsString, IsInt, Min, Max } from 'class-validator';
+
+export class AuditLogQueryDto {
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  @Type(() => Date)
+  dateFrom?: Date;
+
+  @IsOptional()
+  @IsISO8601()
+  @Type(() => Date)
+  dateTo?: Date;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}


### PR DESCRIPTION
- Create AuditLogQueryDto with proper date validation
- Prevents 500 errors on malformed date strings
- Uses class-transformer @Type(() => Date)

Closes #687