### PR TITLE
fix: add path traversal validation in deleteAvatar method

### DIFF
--- a/src/users/avatar-upload.service.ts
+++ b/src/users/avatar-upload.service.ts
@@ -3,7 +3,7 @@
 import { Injectable, BadRequestException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import { createHash } from 'crypto';
 
 // Multer type definition
@@ -86,14 +86,30 @@ export class AvatarUploadService {
 
   async deleteAvatar(userId: string, filename: string): Promise<void> {
     const userDir = join(this.uploadDir, userId);
+    const resolvedUserDir = resolve(userDir);
+
+    if (!/^[A-Za-z0-9._-]+$/.test(filename)) {
+      throw new BadRequestException('Invalid filename');
+    }
 
     try {
       // Delete all size variants
       const sizes = ['small_', 'medium_', 'large_', ''];
       for (const prefix of sizes) {
         const filePath = join(userDir, `${prefix}${filename}`);
+        const resolvedFilePath = resolve(filePath);
+        const normalizedRelativePath = relative(resolvedUserDir, resolvedFilePath);
+
+        if (
+          normalizedRelativePath.startsWith('..') ||
+          isAbsolute(normalizedRelativePath) ||
+          normalizedRelativePath === ''
+        ) {
+          throw new BadRequestException('Invalid filename');
+        }
+
         try {
-          await fs.unlink(filePath);
+          await fs.unlink(resolvedFilePath);
         } catch (error) {
           // File might not exist, continue
         }
@@ -109,6 +125,9 @@ export class AvatarUploadService {
       this.logger.log(`Avatar deleted successfully for user ${userId}`);
     } catch (error) {
       this.logger.error(`Error deleting avatar for user ${userId}:`, error);
+      if (error instanceof BadRequestException) {
+        throw error;
+      }
       throw new BadRequestException('Failed to delete avatar');
     }
   }

--- a/test/users/avatar-upload.spec.ts
+++ b/test/users/avatar-upload.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
 import { AvatarUploadController } from '../../src/users/avatar-upload.controller';
 import { AvatarUploadService } from '../../src/users/avatar-upload.service';
 import { UsersService } from '../../src/users/users.service';
@@ -8,6 +9,24 @@ describe('AvatarUploadController', () => {
   let controller: AvatarUploadController;
   let avatarUploadService: AvatarUploadService;
   let usersService: UsersService;
+
+  describe('AvatarUploadService', () => {
+    let service: AvatarUploadService;
+
+    beforeEach(() => {
+      const configService = {
+        get: jest.fn((key: string, defaultValue?: string | number) => defaultValue),
+      } as unknown as ConfigService;
+
+      service = new AvatarUploadService(configService);
+    });
+
+    it('should reject filenames that attempt path traversal', async () => {
+      await expect(service.deleteAvatar('user_123', '../../secret.txt')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
 
   const mockUser = {
     id: 'user_123',


### PR DESCRIPTION
Closes #685 

## ✅ Update completed

The path traversal issue in avatar deletion has been fixed.

- avatar-upload.service.ts now:
  - rejects invalid filenames with the allowed pattern `^[A-Za-z0-9._-]+$`
  - resolves the candidate path and ensures it remains inside the user’s avatar directory before deleting anything

- avatar-upload.spec.ts now includes a regression test for a traversal-style filename such as `../../secret.txt`.

### Verification
- Editor diagnostics currently report no errors in the updated files.

Made changes.