### PR TITLE
fix: remap Prisma errors to NestJS exceptions in generateReport

### DIFF
--- a/src/properties/properties.controller.ts
+++ b/src/properties/properties.controller.ts
@@ -13,6 +13,8 @@ import {
   UseGuards,
   Res,
   HttpStatus,
+  NotFoundException,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { PropertiesService } from './properties.service';
 import { CreatePropertyDto, UpdatePropertyDto } from './dto/property.dto';
@@ -106,13 +108,19 @@ export class PropertiesController {
 
       res.send(pdfBuffer);
     } catch (error) {
-      if (error.message?.includes('not found')) {
-        res.status(HttpStatus.NOT_FOUND).send({ message: error.message });
-        return;
+      // Re-throw known NestJS HTTP exceptions so the global exception filter
+      // handles them correctly without leaking internal details.
+      if (error instanceof NotFoundException || error instanceof InternalServerErrorException) {
+        throw error;
       }
-      res
-        .status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .send({ message: 'Failed to generate property report' });
+
+      // Remap Prisma "not found" errors to a safe NotFoundException.
+      if (error?.code === 'P2025' || error?.name === 'NotFoundError') {
+        throw new NotFoundException(`Property with id "${id}" was not found`);
+      }
+
+      // All other unexpected errors become a generic 500 with no internal detail.
+      throw new InternalServerErrorException('Failed to generate property report');
     }
   }
 


### PR DESCRIPTION
Closes #690 

- Replace raw error.message string matching on 'not found' which could leak internal Prisma error details to callers
- Re-throw existing NestJS HTTP exceptions untouched
- Remap Prisma P2025 / NotFoundError to NotFoundException with a safe redacted message
- Map all other errors to InternalServerErrorException with a generic message