### PR TITLE
fix: Ensure singleton DI for CacheMetricsInterceptor

### DIFF
--- a/src/cache/cache-metrics.interceptor.ts
+++ b/src/cache/cache-metrics.interceptor.ts
@@ -12,6 +12,7 @@ import { CacheMonitoringService } from './cache-monitoring.service';
 
 @Injectable()
 export class CacheMetricsInterceptor implements NestInterceptor {
+  // CacheMonitoringService is expected to be a singleton provided by the CacheModule
   constructor(private cacheMonitoringService: CacheMonitoringService) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,8 +51,9 @@ async function bootstrap() {
   app.useGlobalInterceptors(new RateLimitHeadersInterceptor());
 
   // Apply cache metrics interceptor
-  const cacheMonitoringService = app.get(CacheMonitoringService);
-  app.useGlobalInterceptors(new CacheMetricsInterceptor(cacheMonitoringService));
+  // Retrieve the singleton instance from the DI container to ensure consistent dependency injection
+  const cacheMetricsInterceptor = app.get(CacheMetricsInterceptor);
+  app.useGlobalInterceptors(cacheMetricsInterceptor);
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
Re-opening fix for CacheMetricsInterceptor dependency injection issue. Closes #688.