### PR TITLE
refactor: remove any casts for prisma client models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9722,7 +9722,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17422,7 +17421,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {

--- a/src/commissions/commissions.service.ts
+++ b/src/commissions/commissions.service.ts
@@ -49,7 +49,7 @@ export class CommissionsService {
         const amount = transaction.amount.mul(agentAssignment.commissionRate);
 
         // Check if commission record already exists
-        const existing = await (this.prisma as any).commission.findUnique({
+        const existing = await this.prisma.commission.findUnique({
           where: {
             transactionId_agentId: {
               transactionId,
@@ -65,7 +65,7 @@ export class CommissionsService {
           continue;
         }
 
-        await (this.prisma as any).commission.create({
+        await this.prisma.commission.create({
           data: {
             transactionId,
             agentId: agentAssignment.agentId,
@@ -96,7 +96,7 @@ export class CommissionsService {
       const dbStatus =
         status === 'COMPLETED' ? 'COMPLETED' : status === 'CANCELLED' ? 'CANCELLED' : 'PENDING';
 
-      const result = await (this.prisma as any).commission.updateMany({
+      const result = await this.prisma.commission.updateMany({
         where: { transactionId },
         data: { status: dbStatus as any },
       });
@@ -142,7 +142,7 @@ export class CommissionsService {
     }
 
     const [items, total] = await Promise.all([
-      (this.prisma as any).commission.findMany({
+      this.prisma.commission.findMany({
         where,
         skip,
         take: limit,
@@ -172,7 +172,7 @@ export class CommissionsService {
         },
         orderBy: { createdAt: 'desc' },
       }),
-      (this.prisma as any).commission.count({ where }),
+      this.prisma.commission.count({ where }),
     ]);
 
     return {
@@ -195,7 +195,7 @@ export class CommissionsService {
    * Find details of a single commission record
    */
   async findOne(id: string, user: AuthUserPayload) {
-    const commission = await (this.prisma as any).commission.findUnique({
+    const commission = await this.prisma.commission.findUnique({
       where: { id },
       include: {
         agent: {
@@ -256,31 +256,31 @@ export class CommissionsService {
   async getStats(user: AuthUserPayload) {
     if (user.role === 'ADMIN') {
       // Global Statistics
-      const completedAgg = await (this.prisma as any).commission.aggregate({
+      const completedAgg = await this.prisma.commission.aggregate({
         _sum: { amount: true },
         where: { status: 'COMPLETED' },
       });
 
-      const pendingAgg = await (this.prisma as any).commission.aggregate({
+      const pendingAgg = await this.prisma.commission.aggregate({
         _sum: { amount: true },
         where: { status: 'PENDING' },
       });
 
-      const cancelledAgg = await (this.prisma as any).commission.aggregate({
+      const cancelledAgg = await this.prisma.commission.aggregate({
         _sum: { amount: true },
         where: { status: 'CANCELLED' },
       });
 
       // Get count of completed vs pending
-      const completedCount = await (this.prisma as any).commission.count({
+      const completedCount = await this.prisma.commission.count({
         where: { status: 'COMPLETED' },
       });
-      const pendingCount = await (this.prisma as any).commission.count({
+      const pendingCount = await this.prisma.commission.count({
         where: { status: 'PENDING' },
       });
 
       // Breakdown per agent
-      const commissions = await (this.prisma as any).commission.findMany({
+      const commissions = await this.prisma.commission.findMany({
         include: {
           agent: {
             select: {
@@ -330,21 +330,21 @@ export class CommissionsService {
       };
     } else {
       // Agent-specific Statistics
-      const completedAgg = await (this.prisma as any).commission.aggregate({
+      const completedAgg = await this.prisma.commission.aggregate({
         _sum: { amount: true },
         where: { agentId: user.sub, status: 'COMPLETED' },
       });
 
-      const pendingAgg = await (this.prisma as any).commission.aggregate({
+      const pendingAgg = await this.prisma.commission.aggregate({
         _sum: { amount: true },
         where: { agentId: user.sub, status: 'PENDING' },
       });
 
-      const completedCount = await (this.prisma as any).commission.count({
+      const completedCount = await this.prisma.commission.count({
         where: { agentId: user.sub, status: 'COMPLETED' },
       });
 
-      const pendingCount = await (this.prisma as any).commission.count({
+      const pendingCount = await this.prisma.commission.count({
         where: { agentId: user.sub, status: 'PENDING' },
       });
 

--- a/src/duplicate-detection/duplicate-detection.service.ts
+++ b/src/duplicate-detection/duplicate-detection.service.ts
@@ -267,7 +267,7 @@ export class DuplicateDetectionService {
   }
 
   async getFlags(): Promise<any[]> {
-    return (this.prisma as any).propertyDuplicate.findMany({
+    return this.prisma.propertyDuplicate.findMany({
       where: { flaggedForReview: true, isMerged: false, isResolved: false },
       include: {
         property: {
@@ -282,13 +282,13 @@ export class DuplicateDetectionService {
   }
 
   async resolveFlag(flagId: string): Promise<any> {
-    const flag = await (this.prisma as any).propertyDuplicate.findUnique({
+    const flag = await this.prisma.propertyDuplicate.findUnique({
       where: { id: flagId },
     });
     if (!flag) {
       throw new NotFoundException('Duplicate flag not found');
     }
-    return (this.prisma as any).propertyDuplicate.update({
+    return this.prisma.propertyDuplicate.update({
       where: { id: flagId },
       data: { isResolved: true },
     });

--- a/src/properties/properties.service.ts
+++ b/src/properties/properties.service.ts
@@ -849,7 +849,7 @@ export class PropertiesService {
       throw new BadRequestException('Assigned user must have the AGENT role');
     }
 
-    const existing = await (this.prisma as any).propertyAgent.findUnique({
+    const existing = await this.prisma.propertyAgent.findUnique({
       where: {
         propertyId_agentId: {
           propertyId,
@@ -861,7 +861,7 @@ export class PropertiesService {
       throw new BadRequestException('Agent is already assigned to this property');
     }
 
-    return (this.prisma as any).propertyAgent.create({
+    return this.prisma.propertyAgent.create({
       data: {
         propertyId,
         agentId: dto.agentId,
@@ -905,7 +905,7 @@ export class PropertiesService {
       );
     }
 
-    const assignment = await (this.prisma as any).propertyAgent.findUnique({
+    const assignment = await this.prisma.propertyAgent.findUnique({
       where: {
         propertyId_agentId: {
           propertyId,
@@ -917,7 +917,7 @@ export class PropertiesService {
       throw new NotFoundException('Agent assignment not found for this property');
     }
 
-    return (this.prisma as any).propertyAgent.update({
+    return this.prisma.propertyAgent.update({
       where: {
         propertyId_agentId: {
           propertyId,
@@ -958,7 +958,7 @@ export class PropertiesService {
       );
     }
 
-    const assignment = await (this.prisma as any).propertyAgent.findUnique({
+    const assignment = await this.prisma.propertyAgent.findUnique({
       where: {
         propertyId_agentId: {
           propertyId,
@@ -970,7 +970,7 @@ export class PropertiesService {
       throw new NotFoundException('Agent assignment not found for this property');
     }
 
-    return (this.prisma as any).propertyAgent.delete({
+    return this.prisma.propertyAgent.delete({
       where: {
         propertyId_agentId: {
           propertyId,
@@ -988,7 +988,7 @@ export class PropertiesService {
       throw new NotFoundException('Property not found');
     }
 
-    const assignments = await (this.prisma as any).propertyAgent.findMany({
+    const assignments = await this.prisma.propertyAgent.findMany({
       where: { propertyId },
       include: {
         agent: {
@@ -1023,7 +1023,7 @@ export class PropertiesService {
     if (!property) {
       throw new NotFoundException('Property not found');
     }
-    return (this.prisma as any).propertyAmenity.create({
+    return this.prisma.propertyAmenity.create({
       data: {
         propertyId,
         name: dto.name,
@@ -1039,20 +1039,20 @@ export class PropertiesService {
     if (!property) {
       throw new NotFoundException('Property not found');
     }
-    return (this.prisma as any).propertyAmenity.findMany({
+    return this.prisma.propertyAmenity.findMany({
       where: { propertyId },
       orderBy: { createdAt: 'asc' },
     });
   }
 
   async updateAmenity(propertyId: string, amenityId: string, dto: UpdateAmenityDto) {
-    const amenity = await (this.prisma as any).propertyAmenity.findUnique({
+    const amenity = await this.prisma.propertyAmenity.findUnique({
       where: { id: amenityId },
     });
     if (!amenity || amenity.propertyId !== propertyId) {
       throw new NotFoundException('Amenity not found for this property');
     }
-    return (this.prisma as any).propertyAmenity.update({
+    return this.prisma.propertyAmenity.update({
       where: { id: amenityId },
       data: {
         name: dto.name,
@@ -1064,12 +1064,12 @@ export class PropertiesService {
   }
 
   async removeAmenity(propertyId: string, amenityId: string) {
-    const amenity = await (this.prisma as any).propertyAmenity.findUnique({
+    const amenity = await this.prisma.propertyAmenity.findUnique({
       where: { id: amenityId },
     });
     if (!amenity || amenity.propertyId !== propertyId) {
       throw new NotFoundException('Amenity not found for this property');
     }
-    return (this.prisma as any).propertyAmenity.delete({ where: { id: amenityId } });
+    return this.prisma.propertyAmenity.delete({ where: { id: amenityId } });
   }
 }

--- a/src/support-tickets/support-tickets.service.ts
+++ b/src/support-tickets/support-tickets.service.ts
@@ -14,21 +14,21 @@ export class SupportTicketsService {
 
   async addInternalNote(ticketId: string, authorId: string, content: string) {
     await this.assertTicketExists(ticketId);
-    return (this.prisma as any).transactionNote.create({
+    return this.prisma.transactionNote.create({
       data: { transactionId: ticketId, authorId, content, isPublic: false },
     });
   }
 
   async addPublicReply(ticketId: string, authorId: string, content: string) {
     await this.assertTicketExists(ticketId);
-    return (this.prisma as any).transactionNote.create({
+    return this.prisma.transactionNote.create({
       data: { transactionId: ticketId, authorId, content, isPublic: true },
     });
   }
 
   async listForAgent(ticketId: string) {
     await this.assertTicketExists(ticketId);
-    return (this.prisma as any).transactionNote.findMany({
+    return this.prisma.transactionNote.findMany({
       where: { transactionId: ticketId },
       orderBy: { createdAt: 'asc' },
     });
@@ -36,7 +36,7 @@ export class SupportTicketsService {
 
   async listPublicForUser(ticketId: string) {
     await this.assertTicketExists(ticketId);
-    return (this.prisma as any).transactionNote.findMany({
+    return this.prisma.transactionNote.findMany({
       where: { transactionId: ticketId, isPublic: true },
       orderBy: { createdAt: 'asc' },
     });

--- a/src/transactions/transaction-reminders.service.ts
+++ b/src/transactions/transaction-reminders.service.ts
@@ -78,7 +78,7 @@ export class TransactionRemindersService {
         sent++;
       }
 
-      await (this.prisma as any).transactionMilestone.update({
+      await this.prisma.transactionMilestone.update({
         where: { id: milestone.id },
         data: { reminderSentAt: new Date() },
       });


### PR DESCRIPTION
Closes #769

---

## Description
Resolves #[769](https://github.com/MettaChain/PropChain-BackEnd/issues/769).

Updated Prisma client types by running `db:generate` and removed all legacy `(this.prisma as any)` typecasts across various services to enforce strict type checking on the newly generated models.

### Changes
* **src/commissions/commissions.service.ts**: Removed `any` casts.
* **src/support-tickets/support-tickets.service.ts**: Removed `any` casts.
* **src/properties/properties.service.ts**: Removed `any` casts.
* **src/duplicate-detection/duplicate-detection.service.ts**: Removed `any` casts.
* **src/transactions/transaction-reminders.service.ts**: Removed a lingering `any` cast.
* (`admin.service.ts` and `transaction-notes.service.ts` were already clean).