### PR TITLE
Implement env-driven signed URL strategy providers

### DIFF
--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -8,6 +8,8 @@ import { AuthModule } from '../auth/auth.module';
 import { SignedUrlService } from './signed-url/signed-url.service';
 import { NotConfiguredSignedUrlProvider } from './signed-url/not-configured.signed-url-provider';
 import { S3SignedUrlProvider } from './signed-url/s3-signed-url-provider';
+import { GcsSignedUrlProvider } from './signed-url/gcs-signed-url-provider';
+import { AzureSignedUrlProvider } from './signed-url/azure-signed-url-provider';
 import { DocumentsDownloadController } from './documents-download.controller';
 import { SignedUrlProvider } from './signed-url/signed-url-provider.interface';
 
@@ -18,7 +20,9 @@ export const SIGNED_URL_PROVIDER_TOKEN = 'SIGNED_URL_PROVIDER_TOKEN';
  * SIGNED_URL_PROVIDER environment variable.
  *
  * Supported values:
- *   - 's3'          -> S3SignedUrlProvider (requires AWS credentials)
+ *   - 's3'          -> S3SignedUrlProvider (no-op shell for integrators)
+ *   - 'gcs'         -> GcsSignedUrlProvider (no-op shell for integrators)
+ *   - 'azure'       -> AzureSignedUrlProvider (no-op shell for integrators)
  *   - (unset/other) -> NotConfiguredSignedUrlProvider (throws a configured error)
  */
 function signedUrlProviderFactory(): new (...args: any[]) => SignedUrlProvider {
@@ -26,6 +30,10 @@ function signedUrlProviderFactory(): new (...args: any[]) => SignedUrlProvider {
   switch (provider) {
     case 's3':
       return S3SignedUrlProvider;
+    case 'gcs':
+      return GcsSignedUrlProvider;
+    case 'azure':
+      return AzureSignedUrlProvider;
     default:
       return NotConfiguredSignedUrlProvider;
   }

--- a/src/documents/signed-url/azure-signed-url-provider.ts
+++ b/src/documents/signed-url/azure-signed-url-provider.ts
@@ -8,16 +8,16 @@ import {
 } from './signed-url-provider.interface';
 
 /**
- * Placeholder strategy for AWS S3 signed URLs.
+ * Placeholder strategy for Azure Blob Storage signed URLs.
  * This shell intentionally throws until an integrator wires in a real implementation.
  */
 @Injectable()
-export class S3SignedUrlProvider implements SignedUrlProvider {
+export class AzureSignedUrlProvider implements SignedUrlProvider {
   isConfigured(): boolean {
     return false;
   }
 
   async getSignedUrl(_req: SignedUrlRequest): Promise<SignedUrlResponse> {
-    throw new Error('S3 signed URL provider is not configured.');
+    throw new Error('Azure signed URL provider is not configured.');
   }
 }

--- a/src/documents/signed-url/gcs-signed-url-provider.ts
+++ b/src/documents/signed-url/gcs-signed-url-provider.ts
@@ -8,16 +8,16 @@ import {
 } from './signed-url-provider.interface';
 
 /**
- * Placeholder strategy for AWS S3 signed URLs.
+ * Placeholder strategy for Google Cloud Storage signed URLs.
  * This shell intentionally throws until an integrator wires in a real implementation.
  */
 @Injectable()
-export class S3SignedUrlProvider implements SignedUrlProvider {
+export class GcsSignedUrlProvider implements SignedUrlProvider {
   isConfigured(): boolean {
     return false;
   }
 
   async getSignedUrl(_req: SignedUrlRequest): Promise<SignedUrlResponse> {
-    throw new Error('S3 signed URL provider is not configured.');
+    throw new Error('GCS signed URL provider is not configured.');
   }
 }


### PR DESCRIPTION
This change introduces an env-driven strategy pattern for signed URL generation in the documents module. A factory now selects the active provider based on the SIGNED_URL_PROVIDER environment variable, with explicit S3, GCS, and Azure provider shells that can be wired to real implementations by integrators. The default path remains a not-configured provider that throws a clear error when no backend is selected, making the behavior explicit and extensible for future storage integrations.

Closes the issue requesting signed URL generation to be implemented through a strategy pattern driven by environment variables, with S3/GCS/Azure placeholders and a default not-configured failure mode.

Closes #751 