### PR TITLE
fix(#772): tag admin/fraud routes and role-restricted Swagger badge

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -163,21 +163,25 @@ export class AdminController {
     return this.adminService.updateTransactionStatus(transactionId, payload, user.sub);
   }
 
+  @ApiTags('Fraud')
   @Get('fraud/alerts')
   listFraudAlerts(@Query() query: FraudAlertsQueryDto) {
     return this.adminService.listFraudAlerts(query);
   }
 
+  @ApiTags('Fraud')
   @Get('fraud/alerts/summary')
   getFraudAlertsSummary() {
     return this.adminService.getFraudAlertsSummary();
   }
 
+  @ApiTags('Fraud')
   @Get('fraud/alerts/:id')
   getFraudAlertDetails(@Param('id') alertId: string) {
     return this.adminService.getFraudAlertDetails(alertId);
   }
 
+  @ApiTags('Fraud')
   @Patch('fraud/alerts/:id')
   reviewFraudAlert(
     @Param('id') alertId: string,
@@ -187,6 +191,7 @@ export class AdminController {
     return this.adminService.reviewFraudAlert(alertId, payload, user.sub);
   }
 
+  @ApiTags('Fraud')
   @Post('fraud/alerts/:id/notes')
   addFraudAlertNote(
     @Param('id') alertId: string,
@@ -196,6 +201,7 @@ export class AdminController {
     return this.adminService.addFraudAlertNote(alertId, payload, user.sub);
   }
 
+  @ApiTags('Fraud')
   @Post('fraud/alerts/:id/block-user')
   blockFraudUser(
     @Param('id') alertId: string,
@@ -205,11 +211,13 @@ export class AdminController {
     return this.adminService.blockFraudUser(alertId, user.sub, payload);
   }
 
+  @ApiTags('Fraud')
   @Post('fraud/users/:id/scan')
   scanUserForFraud(@Param('id') userId: string, @CurrentUser() user: AuthUserPayload) {
     return this.adminService.scanUserForFraud(userId, user.sub);
   }
 
+  @ApiTags('Fraud')
   @Post('fraud/properties/:id/scan')
   scanPropertyForFraud(@Param('id') propertyId: string, @CurrentUser() user: AuthUserPayload) {
     return this.adminService.scanPropertyForFraud(propertyId, user.sub);

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -50,6 +50,12 @@ export function setupSwagger(app: INestApplication): void {
     .addTag('Trust Score', 'Trust score calculation and management')
     .addTag('Email', 'Email verification endpoints')
     .addTag('Versioning', 'API versioning information')
+    .addTag('Admin', 'Administrative endpoints — admin role only (role-restricted)')
+    .addTag(
+      'Fraud',
+      'Fraud detection and investigation endpoints — admin role only (role-restricted). ' +
+        'Currently routed through the Admin module; a future change may extract these into a dedicated controller.',
+    )
     .build();
 
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
Closes #772
Closes #771
Closes #773 
Closes #774 

- Verified admin.controller.ts already carries @ApiTags('Admin') at the controller level (no change required there)
- Added @ApiTags('Fraud') at the *method level* on the 8 fraud-related endpoints in admin.controller.ts. NestJS Swagger accumulates the tag list per operation so these endpoints now appear under both Admin and Fraud sections in the Swagger UI without altering their /admin/fraud/* URL paths
- Registered `Admin` and `Fraud` tag descriptions in setupSwagger with explicit 'admin role only (role-restricted)' hints — that's the role-restricted badge from the issue
- src/fraud/fraud.controller.ts does not exist in this codebase today; fraud operations currently nest inside admin.controller.ts. Tagging them at the method level preserves URL stability. Extracting into a dedicated FraudController is recommended as a follow-up (will require API URL changes from /admin/fraud/* to /fraud/*)