### PR TITLE
chore(deps): upgrade class-validator to v0.15.1 (closes #759)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "cache-manager-redis-store": "^3.0.1",
         "canvas": "^3.2.3",
         "class-transformer": "^0.5.1",
-        "class-validator": "^0.14.1",
+        "class-validator": "^0.15.1",
         "csv-parse": "^6.2.1",
         "dotenv": "^16.3.1",
         "ethers": "^6.16.0",
@@ -3562,6 +3562,26 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@nestjs/graphql/node_modules/@nestjs/mapped-types": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
+      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/graphql/node_modules/chokidar": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
@@ -3601,26 +3621,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/@nestjs/mapped-types": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
-      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
-        "reflect-metadata": "^0.1.12 || ^0.2.0"
-      },
-      "peerDependenciesMeta": {
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
       }
     },
     "node_modules/@nestjs/passport": {
@@ -7033,9 +7033,9 @@
       "license": "MIT"
     },
     "node_modules/class-validator": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
-      "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
+      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
       "dependencies": {
         "@types/validator": "^13.15.3",
@@ -9722,7 +9722,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17422,7 +17421,6 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cache-manager-redis-store": "^3.0.1",
     "canvas": "^3.2.3",
     "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.1",
+    "class-validator": "^0.15.1",
     "csv-parse": "^6.2.1",
     "dotenv": "^16.3.1",
     "ethers": "^6.16.0",


### PR DESCRIPTION
Closes #759
Closes #760 
Closes #761 
Closes #762 

- Bump class-validator from ^0.14.1 to ^0.15.1 (resolved 0.15.1)
- class-transformer stays at ^0.5.1 (resolved 0.5.1) - version range unchanged, compatible with v0.15

## Audit performed

@Type(() => Date) (8 sites, all reviewed):
- src/transactions/dto/transactions.dto.ts (lines 29, 34)
- src/transactions/dto/transaction.dto.ts (lines 207, 216)
- src/properties/dto/search-properties.dto.ts (lines 116, 120)
- src/properties/dto/property.dto.ts (lines 143, 233)
Left unchanged. v0.15's stricter IsDate handling is compatible with the global ValidationPipe config (src/main.ts): transform: true + transformOptions.enableImplicitConversion: true. enableImplicitConversion delegates native primitive coercion to class-transformer, and v0.15's stricter Date-string validation continues to reject malformed ISO strings.

@ValidateNested (4 sites, all reviewed):
- src/users/dto/update-profile.dto.ts:105 (ContactHoursDto, paired @Type at 106)
- src/users/dto/update-profile.dto.ts:110 (AddressDto, paired @Type at 111)
- src/neighborhoods/dto/neighborhood.dto.ts:137 (SchoolDto, paired @Type at 138)
- src/neighborhoods/dto/neighborhood.dto.ts:143 (AmenityDto, paired @Type at 144)
All four are already correctly paired with @Type, which is the contract v0.15 enforces strictly. No source changes required.

## Validation
- tsc --noEmit: clean (no type errors)
- Full npm test: 34 suites passed / 1 skipped, 224 tests passed / 2 skipped, 0 failures
- Working tree contained ONLY package.json + package-lock.json changes (lint --fix auto-fixes on unrelated files were reverted before commit)

## Semver note
^0.15.1 allows future 0.15.x patches but blocks 0.16.0 - appropriate for a dep where minor versions historically introduce semantic changes.